### PR TITLE
do not try to capture output in quiet mode

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -180,7 +180,7 @@ class IDCClient:
             series_url, downloadDir]
 
         if not dry_run:
-            process = subprocess.run(cmd, capture_output=True, text=True)
+            process = subprocess.run(cmd, capture_output=(not quiet), text=(not quiet))
             if not quiet:
                 print(process.stderr)
             if process.returncode == 0:


### PR DESCRIPTION
s5cmd output redirect appears to cause troubles in some situations