### PR TITLE
Update to v17, make manifest download more robust, and other refinements

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -277,6 +277,11 @@ class IDCClient:
     Raises:
     """
     def download_from_manifest(self, manifestFile, downloadDir, quiet=True):
+        if not os.path.exists(downloadDir):
+            raise ValueError("Download directory does not exist.")
+        if not os.path.exists(manifestFile):
+            raise ValueError("Manifest does not exist.")
+
         # open manifest_file and read the first line that does not start from '#'
         with open(manifestFile, 'r') as f:
             for line in f:
@@ -307,7 +312,7 @@ class IDCClient:
 
         cmd = [self.s5cmdPath, '--no-sign-request', '--endpoint-url', endpoint_to_use, 'run', os.path.abspath(manifestFile)]
         logger.debug("Running command: "+' '.join(cmd)+" in "+downloadDir)
-        process = subprocess.Popen(cmd, cwd = downloadDir, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        process = subprocess.Popen(cmd, cwd = os.path.abspath(downloadDir), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         out, err = process.communicate()
         logger.info(out)
         logger.info(err)

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -298,14 +298,14 @@ class IDCClient:
         folder_url = match.group(1)
      
         cmd = [self.s5cmdPath, '--no-sign-request', '--endpoint-url', self.aws_endpoint_url, 'ls', folder_url]
-        process = subprocess.run(cmd, capture_output=(not quiet), text=(not quiet))
+        process = subprocess.run(cmd, capture_output=True, text=True)
         # check if output starts with ERROR
-        if process.stderr.startswith('ERROR'):
+        if process.stderr and process.stderr.startswith('ERROR'):
             logger.debug("Folder not available in AWS. Checking in Google Cloud Storage.")
 
             cmd = [self.s5cmdPath, '--no-sign-request', '--endpoint-url', self.gcp_endpoint_url, 'ls', folder_url]
             process = subprocess.run(cmd, capture_output=True, text=True)
-            if process.stdout.startswith('ERROR'):
+            if process.stderr and process.stdout.startswith('ERROR'):
                 logger.debug("Folder not available in GCP. Manifest appears to be invalid.")
                 raise ValueError
             else:
@@ -329,7 +329,7 @@ class IDCClient:
         cmd = [self.s5cmdPath, '--no-sign-request', '--endpoint-url', endpoint_to_use, 'run', temp_manifest_file.name]
 
         logger.debug("Running command: %s", ' '.join(cmd))
-        process = subprocess.run(cmd, capture_output=(not quiet), text=(not quiet)))
+        process = subprocess.run(cmd, capture_output=(not quiet), text=(not quiet))
         logger.debug(process.stderr)
         logger.debug(process.stdout)
         if process.returncode == 0:

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -251,7 +251,7 @@ class IDCClient:
             result_df = self._filter_by_dicom_series_uid(result_df, seriesInstanceUID)
 
         total_size = result_df['series_size_MB'].sum()
-        logger.info("Total size of files to download: ", float(total_size)/1000, "GB")
+        logger.info("Total size of files to download: ", str(float(total_size)/1000), "GB")
         logger.info("Total free space on disk: ", os.statvfs(downloadDir).f_bsize * os.statvfs(downloadDir).f_bavail / (1000*1000*1000), "GB")
 
         if dry_run:

--- a/queries/idc_index.sql
+++ b/queries/idc_index.sql
@@ -1,18 +1,18 @@
 SELECT
   # collection level attributes
   ANY_VALUE(collection_id) AS collection_id,
-  ANY_VALUE(PatientID) AS PatientID,
-  SeriesInstanceUID,
-  ANY_VALUE(StudyInstanceUID) AS StudyInstanceUID,
   ANY_VALUE(source_DOI) AS source_DOI,
   # patient level attributes
+  ANY_VALUE(PatientID) AS PatientID,
   ANY_VALUE(PatientAge) AS PatientAge,
   ANY_VALUE(PatientSex) AS PatientSex,
   # study level attributes
+  ANY_VALUE(StudyInstanceUID) AS StudyInstanceUID,
   ANY_VALUE(StudyDate) AS StudyDate,
   ANY_VALUE(StudyDescription) AS StudyDescription,
   ANY_VALUE(dicom_curated.BodyPartExamined) AS BodyPartExamined,
   # series level attributes
+  SeriesInstanceUID,
   ANY_VALUE(Modality) AS Modality,
   ANY_VALUE(Manufacturer) AS Manufacturer,
   ANY_VALUE(ManufacturerModelName) AS ManufacturerModelName,
@@ -22,12 +22,12 @@ SELECT
   COUNT(dicom_all.SOPInstanceUID) AS instanceCount,
   ANY_VALUE(license_short_name) as license_short_name,
   # download related attributes
-  ANY_VALUE(CONCAT("s3://", SPLIT(aws_url,"/")[SAFE_OFFSET(2)], "/", crdc_series_uuid, "/*")) AS series_aws_url,
+  ANY_VALUE(CONCAT("s3://", aws_bucket, "/", crdc_series_uuid, "/*")) AS series_aws_url,
   ROUND(SUM(SAFE_CAST(instance_size AS float64))/1000000, 2) AS series_size_MB,
 FROM
-  bigquery-public-data.idc_v16.dicom_all AS dicom_all
+  bigquery-public-data.idc_v17.dicom_all AS dicom_all
 JOIN
-  bigquery-public-data.idc_v16.dicom_metadata_curated AS dicom_curated
+  bigquery-public-data.idc_v17.dicom_metadata_curated AS dicom_curated
 ON
   dicom_all.SOPInstanceUID = dicom_curated.SOPInstanceUID
 GROUP BY

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import urllib.request
 import tarfile
 import zipfile
 
-package_version = "0.2.7"
+package_version = "0.2.8"
 
 # Read long description from README
 with open("README.md", "r", encoding="utf-8") as fh:

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -67,13 +67,13 @@ class TestIDCClient(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
           self.client.download_from_manifest(manifestFile="./tests/study_manifest_aws.s5cmd", downloadDir=temp_dir)
 
-          self.assertIsNotNone(os.listdir(temp_dir))
+          self.assertEqual(len(os.listdir(temp_dir)), 15)
 
     def test_download_from_gcp_manifest(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-          self.client.download_from_manifest(manifestFile="./tests/study_manifest_gcs.s5cmd", downloadDir=temp_dir, quiet=True)
+          self.client.download_from_manifest(manifestFile="./tests/study_manifest_gcs.s5cmd", downloadDir=temp_dir)
 
-          self.assertNotEqual(len(os.listdir(temp_dir)),0)
+          self.assertEqual(len(os.listdir(temp_dir)),15)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -39,22 +39,22 @@ class TestIDCClient(unittest.TestCase):
         self.assertIsNotNone(studies)
 
     def test_get_series(self):
-        series = self.client.get_dicom_series(studyInstanceUID="1.3.6.1.4.1.14519.5.2.1.3671.4754.288848219213026850354055725664", outputFormat="list")
+        series = self.client.get_dicom_series(studyInstanceUID="1.3.6.1.4.1.14519.5.2.1.6279.6001.175012972118199124641098335511", outputFormat="list")
 
         self.assertIsNotNone(series)
 
-        series = self.client.get_dicom_series(studyInstanceUID=["1.3.6.1.4.1.14519.5.2.1.3671.4754.288848219213026850354055725664","1.2.840.113704.1.111.2408.1187360342.8"], outputFormat="list")
+        series = self.client.get_dicom_series(studyInstanceUID=["1.3.6.1.4.1.14519.5.2.1.6279.6001.141365756818074696859567662357","1.3.6.1.4.1.14519.5.2.1.6279.6001.239368516910061467349404750170"], outputFormat="list")
 
         self.assertIsNotNone(series)
 
     def test_download_dicom_series(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-          self.client.download_dicom_series(seriesInstanceUID="1.2.840.113704.1.111.3972.1187368426.50", downloadDir=temp_dir)
+          self.client.download_dicom_series(seriesInstanceUID="1.3.6.1.4.1.14519.5.2.1.6279.6001.141365756818074696859567662357", downloadDir=temp_dir)
           self.assertNotEqual(len(os.listdir(temp_dir)),0)
 
     def test_download_from_selection(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-          self.client.download_from_selection(studyInstanceUID="1.3.6.1.4.1.14519.5.2.1.3320.3273.234458321320456015460025860862", downloadDir=temp_dir)
+          self.client.download_from_selection(studyInstanceUID="1.3.6.1.4.1.14519.5.2.1.6279.6001.175012972118199124641098335511", downloadDir=temp_dir)
 
           self.assertNotEqual(len(os.listdir(temp_dir)),0)
 

--- a/tests/study_manifest_aws.s5cmd
+++ b/tests/study_manifest_aws.s5cmd
@@ -1,0 +1,6 @@
+# To download the files in this manifest, first install s5cmd (https://github.com/peak/s5cmd),
+# then run the following command:
+# s5cmd --no-sign-request --endpoint-url https://s3.amazonaws.com run study_manifest_aws.s5cmd
+cp s3://idc-open-data/58719bbb-1356-457a-bfb6-e0bee68e05aa/* .
+cp s3://idc-open-data/f7dbee2f-1f62-466e-bba7-b79e299d03a9/* .
+cp s3://idc-open-data/e3dd4623-d4c9-4d65-8f57-be1bded184a0/* .

--- a/tests/study_manifest_gcs.s5cmd
+++ b/tests/study_manifest_gcs.s5cmd
@@ -1,0 +1,6 @@
+# To download the files in this manifest, first install s5cmd (https://github.com/peak/s5cmd),
+# then run the following command:
+# s5cmd --no-sign-request --endpoint-url https://storage.googleapis.com run study_manifest_gcs.s5cmd
+cp s3://public-datasets-idc/58719bbb-1356-457a-bfb6-e0bee68e05aa/* .
+cp s3://public-datasets-idc/f7dbee2f-1f62-466e-bba7-b79e299d03a9/* .
+cp s3://public-datasets-idc/e3dd4623-d4c9-4d65-8f57-be1bded184a0/* .


### PR DESCRIPTION
* use dedicated logger
* improve manifest download function to identify the right endpoint and support destination directory to address #17
* keep IDC version in a variable
* reorganize the query to be consistent with the comments and use bucket column