### PR TITLE
Create keep-alive.yaml

### DIFF
--- a/.github/workflows/keep-alive.yaml
+++ b/.github/workflows/keep-alive.yaml
@@ -1,0 +1,15 @@
+name: keep-github-actions-alive
+
+on:
+    schedule:
+      - cron: "0 0 * * *"  
+jobs:
+    keep-alive:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+            with:
+                ref: 'keep-alive'
+          - uses: gautamkrishnar/keepalive-workflow@v1
+            with:
+                time_elapsed: 50


### PR DESCRIPTION
A GitHub actions workflow to keep the repository active so that gha continue to run