### PR TITLE
fix: Simplify duckdb dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  'duckdb;python_version<"3.12"',
-  'duckdb>0.9.2;python_version=="3.12"',
+  'duckdb>=0.10.0',
   "pandas<2.2",
   "psutil",
 ]


### PR DESCRIPTION
Following the release of duckdb 0.10.0 supporting Python 3.12, there is no need to install different version depending on the Python version being used.

Follow-up of https://github.com/ImagingDataCommons/idc-index/commit/ac9705cb99de8d72bd96e372f8db464062551160

```
fix: Support Python 3.12 adding dependency to duckdb pre-release

Since the latest regular release of duckdb does not project Python 3.12
wheels, we install the latest pre-release when Python 3.12 is used.