### PR TITLE
exclude .md files from ruff and fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 download of DICOM files hosted by the
 [NCI Imaging Data Commons (IDC)](https://imaging.datacommons.cancer.gov).
 
-🚧 This package is in its early development stages. Its functionality and API 
-will change. Stay tuned for the updates and documentation, and please share 
-your feedback about it by opening issues in this repository, or by starting 
-a discussion in [IDC User forum](https://discourse.canceridc.dev/).🚧
+🚧 This package is in its early development stages. Its functionality and API
+will change. Stay tuned for the updates and documentation, and please share your
+feedback about it by opening issues in this repository, or by starting a
+discussion in [IDC User forum](https://discourse.canceridc.dev/).🚧
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ disallow_incomplete_defs = true
 
 [tool.ruff]
 src = ["idc_index"]
+exclude = [".md"]
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
I am excluding .md files, since it is not clear to me if `ruff` is even able to check Markdown, and if yes - how it should be configured. Without this commit, `ruff` precommit checks fail with messages that do not make sense:

```
error: Failed to parse README.md:3:2: Unexpected token '!'
README.md:3:2: E999 SyntaxError: Unexpected token '!'
Found 1 error.
```

Based on my searches and an [exchange with Perplexity](https://www.perplexity.ai/search/I-am-using-xEPxl6cpROe6DLfnpSGkMA?s=c), I did not find a way to solve this other than disable Markdown in `ruff` configuration.