### PR TITLE
Debug keep-alive gh action

### DIFF
--- a/.github/workflows/keep-alive.yaml
+++ b/.github/workflows/keep-alive.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: "keep-alive"
-      - uses: gautamkrishnar/keepalive-workflow@v1
+      - uses: gautamkrishnar/keepalive-workflow@v2
         with:
           time_elapsed: 50
           use_api: true

--- a/.github/workflows/keep-alive.yaml
+++ b/.github/workflows/keep-alive.yaml
@@ -3,6 +3,10 @@ name: keep-github-actions-alive
 on:
   schedule:
     - cron: "0 0 * * *"
+
+permissions:
+  actions: write
+
 jobs:
   keep-alive:
     runs-on: ubuntu-latest
@@ -13,3 +17,4 @@ jobs:
       - uses: gautamkrishnar/keepalive-workflow@v1
         with:
           time_elapsed: 50
+          use_api: true


### PR DESCRIPTION
Provided write permission, uses GitHub api to keep the gha alive instead of creating an empty commit

Since the behavior is erratic (working fine on some IDC repos and does not on others), I did not test this on my fork
