### PR TITLE
feat: report download progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Test package
         run: >-
           python -m pytest -ra --cov --cov-report=xml --cov-report=term
-          --durations=20
+          --durations=20 -vv
 
 #      - name: Upload coverage report
 #        uses: codecov/codecov-action@v4.1.0

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -1,20 +1,25 @@
+# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import logging
 import os
-import re
 import shutil
 import subprocess
 import tempfile
+import time
 from importlib.metadata import distribution
+from pathlib import Path
 
 import duckdb
 import idc_index_data
 import pandas as pd
 import psutil
 from packaging.version import Version
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
+logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.DEBUG)
 
 aws_endpoint_url = "https://s3.amazonaws.com"
 gcp_endpoint_url = "https://storage.googleapis.com"
@@ -27,7 +32,7 @@ class IDCClient:
         # Read index file
         logger.debug(f"Reading index file v{idc_index_data.__version__}")
         self.index = pd.read_parquet(file_path)
-        self.index = self.index.astype(str).replace("nan", "")
+        # self.index = self.index.astype(str).replace("nan", "")
         self.index["series_size_MB"] = self.index["series_size_MB"].astype(float)
         self.collection_summary = self.index.groupby("collection_id").agg(
             {"Modality": pd.Series.unique, "series_size_MB": "sum"}
@@ -314,48 +319,6 @@ class IDCClient:
 
         return response
 
-    def download_dicom_series(
-        self, seriesInstanceUID, downloadDir, dry_run=False, quiet=True
-    ):
-        """
-        Download the files corresponding to the seriesInstanceUID to the specified directory.
-
-        Args:
-            seriesInstanceUID: string containing the value of DICOM SeriesInstanceUID to filter by
-            downloadDir: string containing the path to the directory to download the files to
-            dry_run: boolean indicating if the download should be a dry run (default: False)
-            quiet: boolean indicating if the output should be suppressed (default: True)
-
-        Returns:
-
-        """
-        series_url = self.index[self.index["SeriesInstanceUID"] == seriesInstanceUID][
-            "series_aws_url"
-        ].iloc[0]
-        logger.debug("AWS Bucket Location: " + series_url)
-
-        cmd = [
-            self.s5cmdPath,
-            "--no-sign-request",
-            "--endpoint-url",
-            aws_endpoint_url,
-            "cp",
-            "--show-progress",
-            series_url,
-            downloadDir,
-        ]
-
-        if not dry_run:
-            process = subprocess.run(
-                cmd, capture_output=(not quiet), text=(not quiet), check=False
-            )
-            if not quiet:
-                print(process.stderr)
-            if process.returncode == 0:
-                logger.debug(f"Successfully downloaded files to {downloadDir}")
-            else:
-                logger.error("Failed to download files.")
-
     def get_series_file_URLs(self, seriesInstanceUID):
         """
         Get the URLs of the files corresponding to the DICOM instances in a given SeriesInstanceUID.
@@ -369,11 +332,11 @@ class IDCClient:
         # Query to get the S3 URL
         s3url_query = f"""
         SELECT
-          series_aws_url
+        series_aws_url
         FROM
-          index
+        index
         WHERE
-          SeriesInstanceUID='{seriesInstanceUID}'
+        SeriesInstanceUID='{seriesInstanceUID}'
         """
         s3url_query_df = self.sql_query(s3url_query)
         s3_url = s3url_query_df.series_aws_url[0]
@@ -391,7 +354,11 @@ class IDCClient:
 
         # Parse the output to get the file names
         lines = output.split("\n")
-        file_names = [s3_url + line.split()[-1] for line in lines if line]
+        file_names = [
+            s3_url + line.split()[-1]
+            for line in lines
+            if line and line.split()[-1].endswith(".dcm")
+        ]
 
         return file_names
 
@@ -415,7 +382,7 @@ class IDCClient:
             available in IDC
 
             viewer_selector: string containing the name of the viewer to use. Must be one of the following:
-            ohif_v2, ohif_v3 or slim. If not provided, default viewers will be used.
+            ohif_v2, ohif_v3, or slim. If not provided, default viewers will be used.
 
         Returns:
             string containing the IDC viewer URL for the given SeriesInstanceUID
@@ -502,6 +469,498 @@ class IDCClient:
 
         return viewer_url
 
+    def _validate_update_manifest_and_get_download_size(
+        self,
+        manifestFile,
+        downloadDir,
+        validate_manifest,
+        show_progress_bar,
+        use_s5cmd_sync_dry_run,
+    ) -> tuple[float, str, Path]:
+        """
+        Validates the manifest file by checking the URLs in the manifest
+
+        Args:
+            manifestFile (str): The path to the manifest file.
+            downloadDir (str): The path to the download directory.
+            validate_manifest (bool, optional): If True, validates the manifest for any errors. Defaults to True.
+            show_progress_bar (bool, optional): If True, tracks the progress of download
+            use_s5cmd_sync_dry_run (bool, optional): If True, improves the accuracy of progress bar in unusual circumstances
+        Returns:
+            total_size (float): The total size of all series in the manifest file.
+            endpoint_to_use (str): The endpoint URL to use (either AWS or GCP).
+            temp_manifest_file(Path): Path to the temporary manifest file for downstream steps
+        Raises:
+            ValueError: If the manifest file does not exist, if any URL in the manifest file is invalid, or if any URL is inaccessible in both AWS and GCP.
+            Exception: If the manifest contains URLs from both AWS and GCP.
+        """
+        logger.debug("manifest validation is requested: " + str(validate_manifest))
+
+        print("Parsing the manifest. Please wait..")
+        # Read the manifest as a csv file
+        manifest_df = pd.read_csv(
+            manifestFile, comment="#", skip_blank_lines=True, header=None
+        )
+
+        # Rename the column
+        manifest_df.columns = ["manifest_cp_cmd"]
+
+        # create a copy of the index
+        index_df_copy = self.index
+
+        # Extract s3 url and crdc_instance_uuid from the manifest copy commands
+        # Next, extract crdc_instance_uuid from aws_series_url in the index and
+        # try to verify if every series in the manifest is present in the index
+
+        sql = """
+            PRAGMA disable_progress_bar;
+            with index_temp as
+            (select
+            seriesInstanceUID,
+            series_aws_url,
+            series_size_MB,
+            regexp_extract(series_aws_url, '(?:.*?\\/){3}([^\\/?#]+)', 1) index_crdc_series_uuid
+            from index_df_copy),
+            manifest_temp as (
+            select
+            manifest_cp_cmd,
+            regexp_extract(manifest_cp_cmd, '(?:.*?\\/){3}([^\\/?#]+)', 1) as manifest_crdc_series_uuid,
+            regexp_replace(regexp_replace(manifest_cp_cmd, 'cp ', ''), '\\s[^\\s]*$', '') as s3_url,
+            from
+            manifest_df
+            )
+            select
+            seriesInstanceuid,
+            s3_url,
+            series_size_MB,
+            index_crdc_series_uuid==manifest_crdc_series_uuid as crdc_series_uuid_match,
+            s3_url==series_aws_url as s3_url_match,
+            CASE WHEN s3_url==series_aws_url THEN 'aws' ELSE 'unknown' END as endpoint
+            from
+            manifest_temp
+            left join index_temp on index_temp.index_crdc_series_uuid = manifest_temp.manifest_crdc_series_uuid
+            """
+        merged_df = duckdb.query(sql).df()
+
+        if validate_manifest:
+            # Check if crdc_instance_uuid is found in the index
+            if not all(merged_df["crdc_series_uuid_match"]):
+                missing_manifest_cp_cmds = merged_df.loc[
+                    ~merged_df["crdc_series_uuid_match"], "manifest_cp_cmd"
+                ]
+                missing_manifest_cp_cmds_str = f"The following manifest copy commands do not have any associated series in the index: {missing_manifest_cp_cmds.tolist()}"
+                raise ValueError(missing_manifest_cp_cmds_str)
+
+            # Check if there are more than one endpoints
+            if len(merged_df["endpoint"].unique()) > 1:
+                raise ValueError(
+                    "Either GCS bucket path is invalid or manifest has a mix of GCS and AWS urls. If so, please use urls from one provider only"
+                )
+
+            if (
+                len(merged_df["endpoint"].unique()) == 1
+                and merged_df["endpoint"].values[0] == "aws"
+            ):
+                endpoint_to_use = aws_endpoint_url
+
+            if (
+                len(merged_df["endpoint"].unique()) == 1
+                and merged_df["endpoint"].values[0] == "unknown"
+            ):
+                cmd = [
+                    self.s5cmdPath,
+                    "--no-sign-request",
+                    "--endpoint-url",
+                    gcp_endpoint_url,
+                    "ls",
+                    merged_df.s3_url.values[0],
+                ]
+                process = subprocess.run(
+                    cmd, capture_output=True, text=True, check=False
+                )
+                if process.stderr and process.stdout.startswith("ERROR"):
+                    logger.debug(
+                        "Folder not available in GCP. Manifest appears to be invalid."
+                    )
+                    if validate_manifest:
+                        raise ValueError
+                else:
+                    endpoint_to_use = gcp_endpoint_url
+
+        elif merged_df["endpoint"].values[0] == "aws":
+            endpoint_to_use = aws_endpoint_url
+        else:
+            endpoint_to_use = gcp_endpoint_url
+
+        # Calculate total size
+        total_size = merged_df["series_size_MB"].sum()
+        total_size = round(total_size, 2)
+
+        # Write a temporary manifest file
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_manifest_file:
+            if (
+                show_progress_bar
+                and use_s5cmd_sync_dry_run
+                and len(os.listdir(downloadDir)) != 0
+            ):
+                merged_df["s5cmd_cmd"] = (
+                    "sync " + merged_df["s3_url"] + " " + downloadDir
+                )
+            else:
+                merged_df["s5cmd_cmd"] = "cp " + merged_df["s3_url"] + " " + downloadDir
+            merged_df["s5cmd_cmd"].to_csv(temp_manifest_file, header=False, index=False)
+            print("Parsing the manifest is finished. Download will begin soon")
+        return total_size, endpoint_to_use, Path(temp_manifest_file.name)
+
+    @staticmethod
+    def _track_download_progress(
+        size_MB: int,
+        downloadDir: str,
+        process: subprocess.Popen,
+        show_progress_bar: bool = True,
+    ):
+        logger.info("Inputs received for tracking download:")
+        logger.info(f"size_MB: {size_MB}")
+        logger.info(f"downloadDir: {downloadDir}")
+        logger.info(f"show_progress_bar: {show_progress_bar}")
+
+        if show_progress_bar:
+            total_size_bytes = size_MB * 10**6  # Convert MB to bytes
+
+            # Calculate the initial size of the directory
+            initial_size_bytes = sum(
+                f.stat().st_size for f in Path(downloadDir).iterdir() if f.is_file()
+            )
+
+            logger.info("Initial size of the directory: %s bytes", initial_size_bytes)
+            logger.info(
+                "Approx. Size of the files need to be downloaded: %s bytes",
+                total_size_bytes,
+            )
+
+            pbar = tqdm(
+                total=total_size_bytes,
+                unit="B",
+                unit_scale=True,
+                desc="Downloading data",
+            )
+
+            while True:
+                downloaded_bytes = (
+                    sum(
+                        f.stat().st_size
+                        for f in Path(downloadDir).iterdir()
+                        if f.is_file()
+                    )
+                    - initial_size_bytes
+                )
+                pbar.n = min(
+                    downloaded_bytes, total_size_bytes
+                )  # Prevent the progress bar from exceeding 100%
+                pbar.refresh()
+
+                if process.poll() is not None:
+                    break
+
+                time.sleep(0.5)
+
+            # Wait for the process to finish
+            stdout, stderr = process.communicate()
+            pbar.close()
+
+        else:
+            while process.poll() is None:
+                time.sleep(0.5)
+
+        # Check if download process completed successfully
+        if process.returncode != 0:
+            error_message = f"Download process failed: {stderr!s}"
+            logger.error(error_message)
+            raise RuntimeError(error_message)
+
+        logger.info("Successfully downloaded files to %s", str(downloadDir))
+
+    def _parse_s5cmd_sync_output_and_generate_synced_manifest(
+        self, stdout, downloadDir
+    ) -> Path:
+        """
+        Parse the output of s5cmd sync --dry-run to extract distinct folders and generate a synced manifest.
+
+        Args:
+            output (str): The output of s5cmd sync --dry-run command.
+            downloadDir (str): The directory to download the files to.
+
+        Returns:
+            Path: The path to the generated synced manifest file.
+            float: Download size in MB
+        """
+        logger.info("Parsing the s5cmd sync dry run output...")
+
+        stdout_df = pd.DataFrame(stdout.splitlines(), columns=["s5cmd_output"])
+
+        # create a copy of the index
+        index_df_copy = self.index
+
+        sql = """
+            PRAGMA disable_progress_bar;
+            with index_temp as
+            (select
+            *,
+            regexp_extract(series_aws_url, '(?:.*?\\/){3}([^\\/?#]+)', 1) index_crdc_series_uuid
+            from index_df_copy),
+            sync_temp as (
+            select
+            distinct
+            concat(regexp_extract(s5cmd_output, 'cp (s3://[^/]+/[^/]+)/.*', 1), '/*') as s3_url,
+            regexp_extract(concat(regexp_extract(s5cmd_output, 'cp (s3://[^/]+/[^/]+)/.*', 1), '/*'),'(?:.*?\\/){3}([^\\/?#]+)',1) as sync_crdc_instance_uuid
+            from
+            stdout_df
+            )
+            select
+            distinct
+            seriesInstanceUID,
+            series_size_MB,
+            s3_url
+            from
+            sync_temp
+            left join index_temp on index_temp.index_crdc_series_uuid = sync_temp.sync_crdc_instance_uuid
+        """
+        merged_df = duckdb.query(sql).df()
+        sync_size = merged_df["series_size_MB"].sum()
+        sync_size_rounded = round(sync_size, 2)
+
+        logger.info(f"sync_size_rounded: {sync_size_rounded}")
+
+        # Write a temporary manifest file
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as synced_manifest:
+            merged_df["s5cmd_cmd"] = "sync " + merged_df["s3_url"] + " " + downloadDir
+            merged_df["s5cmd_cmd"].to_csv(synced_manifest, header=False, index=False)
+            logger.info("Parsing the s5cmd sync dry run output finished")
+        return Path(synced_manifest.name), sync_size_rounded
+
+    def _s5cmd_run(
+        self,
+        endpoint_to_use,
+        manifest_file,
+        total_size,
+        downloadDir,
+        quiet,
+        show_progress_bar,
+        use_s5cmd_sync_dry_run,
+    ):
+        """
+        Executes the s5cmd command to sync files from a given endpoint to a local directory.
+
+        This function first performs a dry run of the s5cmd command to check which files need to be downloaded.
+        If there are files to be downloaded, it generates a new manifest file with the files to be synced and
+        runs the s5cmd command again to download the files. The progress of the download is tracked and printed
+        to the console.
+
+        Args:
+            endpoint_to_use (str): The endpoint URL to download the files from.
+            manifest_file (str): The path to the manifest file listing the files to be downloaded.
+            total_size (float): The total size of the files to be downloaded in MB.
+            downloadDir (str): The local directory where the files will be downloaded.
+            quiet (bool, optional): If True, suppresses the stdout and stderr of the s5cmd command.
+            show_progress_bar (bool, optional): If True, tracks the progress of download
+            use_s5cmd_sync_dry_run (bool, optional): If True, improves the accuracy of progress bar in unusual circumstances
+
+        Raises:
+            subprocess.CalledProcessError: If the s5cmd command fails.
+
+        Returns:
+            None
+        """
+        logger.info("running self._s5cmd_run. Inputs received:")
+        logger.info(f"endpoint_to_use: {endpoint_to_use}")
+        logger.info(f"manifest_file: {manifest_file}")
+        logger.info(f"total_size: {total_size}")
+        logger.info(f"downloadDir: {downloadDir}")
+        logger.info(f"quiet: {quiet}")
+        logger.info(f"show_progress_bar: {show_progress_bar}")
+        logger.info(f"use_s5cmd_sync_dry_run: {use_s5cmd_sync_dry_run}")
+
+        if quiet:
+            stdout = subprocess.DEVNULL
+            stderr = subprocess.DEVNULL
+        else:
+            stdout = None
+            stderr = None
+
+        if (
+            show_progress_bar
+            and use_s5cmd_sync_dry_run
+            and len(os.listdir(downloadDir)) != 0
+        ):
+            logger.info(
+                """
+Requested progress bar along with s5cmd sync dry run.
+Using s5cmd sync dry run as the destination folder is not empty
+"""
+            )
+            dry_run_cmd = [
+                self.s5cmdPath,
+                "--no-sign-request",
+                "--dry-run",
+                "--endpoint-url",
+                endpoint_to_use,
+                "run",
+                manifest_file,
+            ]
+
+            process = subprocess.run(
+                dry_run_cmd, stdout=subprocess.PIPE, text=True, check=False
+            )
+
+            if process.stdout:
+                # Some files need to be downloaded
+                logger.info(
+                    """
+stoud from s5cmd sync dry run is not empty. Parsing the output to
+evaluate what to download and corresponding size with only series level precision
+"""
+                )
+                (
+                    synced_manifest,
+                    sync_size,
+                ) = self._parse_s5cmd_sync_output_and_generate_synced_manifest(
+                    stdout=process.stdout, downloadDir=downloadDir
+                )
+                logger.info(f"sync_size (MB): {sync_size}")
+
+                cmd = [
+                    self.s5cmdPath,
+                    "--no-sign-request",
+                    "--endpoint-url",
+                    endpoint_to_use,
+                    "run",
+                    synced_manifest,
+                ]
+                with subprocess.Popen(
+                    cmd, stdout=stdout, stderr=stderr, universal_newlines=True
+                ) as process:
+                    if sync_size < total_size:
+                        logger.info(
+                            """
+Destination folder is not empty and sync size is less than total size. Displaying a warning
+"""
+                        )
+                        existing_data_size = round(total_size - sync_size, 2)
+                        print(
+                            f"""
+Requested total download size is {total_size} MB, however at least {existing_data_size} MB is already present,
+so downloading only remaining upto {sync_size} MB
+
+Please note that disk sizes are calculated at series level, so if individual files are missing,
+displayed progress bar may not be accurate.
+"""
+                        )
+                        self._track_download_progress(
+                            sync_size, downloadDir, process, show_progress_bar
+                        )
+                    else:
+                        self._track_download_progress(
+                            total_size, downloadDir, process, show_progress_bar
+                        )
+            else:
+                logger.info(
+                    """
+stoud from s5cmd sync dry run is empty, indicating all requested DICOM files are already present in destination folder
+"""
+                )
+                # All requested DICOM files are already present
+                print(
+                    f"All requested DICOM files are already present in {downloadDir}."
+                )
+        else:
+            logger.info(
+                """
+NOT using s5cmd sync dry run as the destination folder IS empty or sync dry or progress bar is not requested
+"""
+            )
+            cmd = [
+                self.s5cmdPath,
+                "--no-sign-request",
+                "--endpoint-url",
+                endpoint_to_use,
+                "run",
+                manifest_file,
+            ]
+            with subprocess.Popen(
+                cmd, stdout=stdout, stderr=stderr, universal_newlines=True
+            ) as process:
+                self._track_download_progress(
+                    total_size, downloadDir, process, show_progress_bar
+                )
+
+    @staticmethod
+    def _format_size(size_MB):
+        size_GB = size_MB / 1000
+        size_TB = size_GB / 1000
+
+        if size_TB >= 1:
+            return f"{round(size_TB, 2)} TB"
+        if size_GB >= 1:
+            return f"{round(size_GB, 2)} GB"
+        return f"{round(size_MB, 2)} MB"
+
+    def download_from_manifest(
+        self,
+        manifestFile: str,
+        downloadDir: str,
+        quiet: bool = True,
+        validate_manifest: bool = True,
+        show_progress_bar: bool = True,
+        use_s5cmd_sync_dry_run: bool = False,
+    ) -> None:
+        """
+        Download the manifest file. In a series of steps, the manifest file
+        is first validated to ensure every line contains a valid urls. It then
+        gets the total size to be downloaded and runs download process on one
+        process and download progress on another process.
+
+        Args:
+            manifestFile (str): The path to the manifest file.
+            downloadDir (str): The directory to download the files to.
+            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
+            validate_manifest (bool, optional): If True, validates the manifest for any errors. Defaults to True.
+            show_progress_bar (bool, optional): If True, tracks the progress of download
+            use_s5cmd_sync_dry_run (bool, optional): If True, improves the accuracy of progress bar in unusual circumstances
+
+        Raises:
+            ValueError: If the download directory does not exist.
+        """
+
+        downloadDir = os.path.abspath(downloadDir).replace("\\", "/")
+        if not os.path.exists(downloadDir):
+            raise ValueError("Download directory does not exist.")
+
+        # validate the manifest
+        (
+            total_size,
+            endpoint_to_use,
+            temp_manifest_file,
+        ) = self._validate_update_manifest_and_get_download_size(
+            manifestFile,
+            downloadDir,
+            validate_manifest,
+            show_progress_bar,
+            use_s5cmd_sync_dry_run,
+        )
+
+        total_size_rounded = round(total_size, 2)
+        print("Total size: " + self._format_size(total_size_rounded))
+
+        self._s5cmd_run(
+            endpoint_to_use=endpoint_to_use,
+            manifest_file=temp_manifest_file,
+            total_size=total_size_rounded,
+            downloadDir=downloadDir,
+            quiet=quiet,
+            show_progress_bar=show_progress_bar,
+            use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+        )
+
     def download_from_selection(
         self,
         downloadDir,
@@ -510,22 +969,33 @@ class IDCClient:
         patientId=None,
         studyInstanceUID=None,
         seriesInstanceUID=None,
+        quiet=True,
+        show_progress_bar=True,
+        use_s5cmd_sync_dry_run=False,
     ):
         """Download the files corresponding to the selection. The filtering will be applied in sequence (but does it matter?) by first selecting the collection(s), followed by
         patient(s), study(studies) and series. If no filtering is applied, all the files will be downloaded.
 
         Args:
+            downloadDir: string containing the path to the directory to download the files to
+            dry_run: calculates the size of the cohort but download does not start
             collection_id: string or list of strings containing the values of collection_id to filter by
             patientId: string or list of strings containing the values of PatientID to filter by
             studyInstanceUID: string or list of strings containing the values of DICOM StudyInstanceUID to filter by
             seriesInstanceUID: string or list of strings containing the values of DICOM SeriesInstanceUID to filter by
-            downloadDir: string containing the path to the directory to download the files to
+            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
+            show_progress_bar (bool, optional): If True, tracks the progress of download
+            use_s5cmd_sync_dry_run (bool, optional): If True, improves the accuracy of progress bar in unusual circumstances
 
         Returns:
 
         Raises:
             TypeError: If any of the parameters are not of the expected type
         """
+
+        downloadDir = os.path.abspath(downloadDir).replace("\\", "/")
+        if not os.path.exists(downloadDir):
+            raise ValueError("Download directory does not exist.")
 
         if collection_id is not None:
             if not isinstance(collection_id, str) and not isinstance(
@@ -560,7 +1030,7 @@ class IDCClient:
         if seriesInstanceUID is not None:
             result_df = self._filter_by_dicom_series_uid(result_df, seriesInstanceUID)
 
-        total_size = result_df["series_size_MB"].sum()
+        total_size = round(result_df["series_size_MB"].sum(), 2)
         logger.info(
             "Total size of files to download: " + str(float(total_size) / 1000) + "GB"
         )
@@ -574,126 +1044,178 @@ class IDCClient:
             logger.info(
                 "Dry run. Not downloading files. Rerun with dry_run=False to download the files."
             )
-            return
+        else:
+            print("Total size: " + self._format_size(total_size))
+            # Download the files
+            # make temporary file to store the list of files to download
+            with tempfile.NamedTemporaryFile(mode="w", delete=False) as manifest_file:
+                if (
+                    show_progress_bar
+                    and use_s5cmd_sync_dry_run
+                    and len(os.listdir(downloadDir)) != 0
+                ):
+                    result_df["s5cmd_cmd"] = (
+                        "sync " + result_df["series_aws_url"] + " " + downloadDir
+                    )
+                else:
+                    result_df["s5cmd_cmd"] = (
+                        "cp " + result_df["series_aws_url"] + " " + downloadDir
+                    )
+                result_df["s5cmd_cmd"].to_csv(manifest_file, header=False, index=False)
+            logger.info(
+                """
+Temporary download manifest is generated and is passed to self._s5cmd_run
+"""
+            )
+            self._s5cmd_run(
+                endpoint_to_use=aws_endpoint_url,
+                manifest_file=Path(manifest_file.name),
+                total_size=total_size,
+                downloadDir=downloadDir,
+                quiet=quiet,
+                show_progress_bar=show_progress_bar,
+                use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+            )
 
-        # Download the files
-        # make temporary file to store the list of files to download
-        manifest_file = os.path.join(downloadDir, "download_manifest.s5cmd")
-        for index, row in result_df.iterrows():
-            with open(manifest_file, "a") as f:
-                f.write(
-                    "cp --show-progress "
-                    + row["series_aws_url"]
-                    + " "
-                    + downloadDir
-                    + "\n"
-                )
-        self.download_from_manifest(manifest_file, downloadDir)
-
-    def download_from_manifest(self, manifestFile, downloadDir, quiet=True):
-        """Download the files corresponding to the manifest file from IDC. The manifest file should be a text file with each line containing the s5cmd command to download the file. The URLs in the file must correspond to those in the AWS buckets!
+    def download_dicom_series(
+        self,
+        seriesInstanceUID,
+        downloadDir,
+        dry_run=False,
+        quiet=True,
+        show_progress_bar=True,
+        use_s5cmd_sync_dry_run=False,
+    ) -> None:
+        """
+        Download the files corresponding to the seriesInstanceUID to the specified directory.
 
         Args:
-            manifest_file: string containing the path to the manifest file
+            seriesInstanceUID: string or list of strings containing the values of DICOM SeriesInstanceUID to filter by
             downloadDir: string containing the path to the directory to download the files to
+            dry_run: calculates the size of the cohort but download does not start
+            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
+            show_progress_bar (bool, optional): If True, tracks the progress of download
+            use_s5cmd_sync_dry_run (bool, optional): If True, improves the accuracy of progress bar in unusual circumstances
 
-        Returns:
+        Returns: None
 
         Raises:
+            TypeError: If seriesInstanceUID(s) passed is(are) not a string or list
+
         """
-
-        downloadDir = os.path.abspath(downloadDir).replace("\\", "/")
-
-        if not os.path.exists(downloadDir):
-            raise ValueError("Download directory does not exist.")
-        if not os.path.exists(manifestFile):
-            raise ValueError("Manifest does not exist.")
-
-        # open manifest_file and read the first line that does not start from '#'
-        with open(manifestFile) as f:
-            for line in f:
-                if not line.startswith("#"):
-                    break
-        pattern = r"(s3:\/\/.*)\/\*"
-        match = re.search(pattern, line)
-        if match is None:
-            logger.error(
-                "Could not find the bucket URL in the first line of the manifest file."
-            )
-            return
-        folder_url = match.group(1)
-
-        cmd = [
-            self.s5cmdPath,
-            "--no-sign-request",
-            "--endpoint-url",
-            aws_endpoint_url,
-            "ls",
-            folder_url,
-        ]
-        process = subprocess.run(cmd, capture_output=True, text=True, check=False)
-        # check if output starts with ERROR
-        if process.stderr and process.stderr.startswith("ERROR"):
-            logger.debug(
-                "Folder not available in AWS. Checking in Google Cloud Storage."
-            )
-
-            cmd = [
-                self.s5cmdPath,
-                "--no-sign-request",
-                "--endpoint-url",
-                gcp_endpoint_url,
-                "ls",
-                folder_url,
-            ]
-            process = subprocess.run(cmd, capture_output=True, text=True, check=False)
-            if process.stderr and process.stdout.startswith("ERROR"):
-                logger.debug(
-                    "Folder not available in GCP. Manifest appears to be invalid."
-                )
-                raise ValueError
-            else:
-                endpoint_to_use = gcp_endpoint_url
-        else:
-            endpoint_to_use = aws_endpoint_url
-
-        # create an updated manifest to include the specified destination directory
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_manifest_file:
-            with open(manifestFile) as f:
-                for line in f:
-                    if not line.startswith("#"):
-                        pattern = r"s3:\/\/.*\*"
-                        match = re.search(pattern, line)
-                        if folder_url is None:
-                            logger.error(
-                                "Could not find the bucket URL in the first line of the manifest file."
-                            )
-                            return
-                        folder_url = match.group(0)
-                        temp_manifest_file.write(
-                            " cp " + folder_url + " " + downloadDir + "\n"
-                        )
-
-        cmd = [
-            self.s5cmdPath,
-            "--no-sign-request",
-            "--endpoint-url",
-            endpoint_to_use,
-            "run",
-            temp_manifest_file.name,
-        ]
-
-        logger.debug("Running command: %s", " ".join(cmd))
-        process = subprocess.run(
-            cmd, capture_output=(not quiet), text=(not quiet), check=False
+        self.download_from_selection(
+            downloadDir,
+            seriesInstanceUID=seriesInstanceUID,
+            dry_run=dry_run,
+            quiet=quiet,
+            show_progress_bar=show_progress_bar,
+            use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
         )
-        logger.debug(process.stderr)
-        logger.debug(process.stdout)
-        if process.returncode == 0:
-            logger.debug(f"Successfully downloaded files to {downloadDir}")
-            logger.debug("Downloaded files: " + "\n".join(os.listdir(downloadDir)))
-        else:
-            logger.error("Failed to download files.")
+
+    def download_dicom_studies(
+        self,
+        studyInstanceUID,
+        downloadDir,
+        dry_run=False,
+        quiet=True,
+        show_progress_bar=True,
+        use_s5cmd_sync_dry_run=False,
+    ) -> None:
+        """
+        Download the files corresponding to the studyInstanceUID to the specified directory.
+
+        Args:
+            studyInstanceUID: string or list of strings containing the values of DICOM studyInstanceUID to filter by
+            downloadDir: string containing the path to the directory to download the files to
+            dry_run: calculates the size of the cohort but download does not start
+            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
+            show_progress_bar (bool, optional): If True, tracks the progress of download
+            use_s5cmd_sync_dry_run (bool, optional): If True, improves the accuracy of progress bar in unusual circumstances
+
+        Returns: None
+
+        Raises:
+            TypeError: If seriesInstanceUID(s) passed is(are) not a string or list
+
+        """
+        self.download_from_selection(
+            downloadDir,
+            studyInstanceUID=studyInstanceUID,
+            dry_run=dry_run,
+            quiet=quiet,
+            show_progress_bar=show_progress_bar,
+            use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+        )
+
+    def download_dicom_patients(
+        self,
+        patientId,
+        downloadDir,
+        dry_run=False,
+        quiet=True,
+        show_progress_bar=True,
+        use_s5cmd_sync_dry_run=False,
+    ) -> None:
+        """
+        Download the files corresponding to the studyInstanceUID to the specified directory.
+
+        Args:
+            patientId: string or list of strings containing the values of DICOM patientId to filter by
+            downloadDir: string containing the path to the directory to download the files to
+            dry_run: calculates the size of the cohort but download does not start
+            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
+            show_progress_bar (bool, optional): If True, tracks the progress of download
+            use_s5cmd_sync_dry_run (bool, optional): If True, improves the accuracy of progress bar in unusual circumstances
+
+        Returns: None
+
+        Raises:
+            TypeError: If patientId(s) passed is(are) not a string or list
+
+        """
+        self.download_from_selection(
+            downloadDir,
+            patientId=patientId,
+            dry_run=dry_run,
+            quiet=quiet,
+            show_progress_bar=show_progress_bar,
+            use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+        )
+
+    def download_collection(
+        self,
+        collection_id,
+        downloadDir,
+        dry_run=False,
+        quiet=True,
+        show_progress_bar=True,
+        use_s5cmd_sync_dry_run=False,
+    ) -> None:
+        """
+        Download the files corresponding to the studyInstanceUID to the specified directory.
+
+        Args:
+            collection_id: string or list of strings containing the values of DICOM patientId to filter by
+            downloadDir: string containing the path to the directory to download the files to
+            dry_run: calculates the size of the cohort but download does not start
+            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
+            show_progress_bar (bool, optional): If True, tracks the progress of download
+            use_s5cmd_sync_dry_run (bool, optional): If True, improves the accuracy of progress bar in unusual circumstances
+
+        Returns: None
+
+        Raises:
+            TypeError: If collection_id(s) passed is(are) not a string or list
+
+        """
+        self.download_from_selection(
+            downloadDir,
+            collection_id=collection_id,
+            dry_run=dry_run,
+            quiet=quiet,
+            show_progress_bar=show_progress_bar,
+            use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+        )
 
     def sql_query(self, sql_query):
         """Execute SQL query against the table in the index using duckdb.

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -881,7 +881,8 @@ NOT using s5cmd sync dry run as the destination folder IS empty or sync dry or p
                 manifest_file,
             ]
 
-            stderr_log_file = tempfile.NamedTemporaryFile(delete=False)
+            # fedorov: did consider-using-with, and decided against it to keep the code more readable
+            stderr_log_file = tempfile.NamedTemporaryFile(delete=False)  # pylint: disable=consider-using-with
 
             with subprocess.Popen(
                 cmd,

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -904,7 +904,7 @@ NOT using s5cmd sync dry run as the destination folder IS empty or sync dry or p
                         if line.startswith("ERROR"):
                             runtime_errors.append(line)
 
-                Path.unlink(stderr_log_file.name)
+                Path(stderr_log_file.name).unlink()
 
                 if len(runtime_errors) > 0:
                     logger.error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "psutil",
   "pyarrow",
   "s5cmd",
+  "tqdm"
 ]
 
 [project.optional-dependencies]

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -4,6 +4,7 @@ import logging
 import os
 import tempfile
 import unittest
+from itertools import product
 
 import pytest
 from idc_index import index
@@ -87,13 +88,41 @@ class TestIDCClient(unittest.TestCase):
             self.assertNotEqual(len(os.listdir(temp_dir)), 0)
 
     def test_download_from_selection(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            self.client.download_from_selection(
-                studyInstanceUID="1.3.6.1.4.1.14519.5.2.1.6279.6001.175012972118199124641098335511",
-                downloadDir=temp_dir,
-            )
+        # Define the values for each optional parameter
+        dry_run_values = [True, False]
+        quiet_values = [True, False]
+        show_progress_bar_values = [True, False]
+        use_s5cmd_sync_dry_run_values = [True, False]
 
-            self.assertNotEqual(len(os.listdir(temp_dir)), 0)
+        # Generate all combinations of optional parameters
+        combinations = product(
+            dry_run_values,
+            quiet_values,
+            show_progress_bar_values,
+            use_s5cmd_sync_dry_run_values,
+        )
+
+        # Test each combination
+        for (
+            dry_run,
+            quiet,
+            show_progress_bar,
+            use_s5cmd_sync_dry_run,
+        ) in combinations:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self.client.download_from_selection(
+                    downloadDir=temp_dir,
+                    dry_run=dry_run,
+                    patientId=None,
+                    studyInstanceUID="1.3.6.1.4.1.14519.5.2.1.6279.6001.175012972118199124641098335511",
+                    seriesInstanceUID=None,
+                    quiet=quiet,
+                    show_progress_bar=show_progress_bar,
+                    use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+                )
+
+                if not dry_run:
+                    self.assertNotEqual(len(os.listdir(temp_dir)), 0)
 
     def test_sql_queries(self):
         df = self.client.sql_query("SELECT DISTINCT(collection_id) FROM index")
@@ -101,20 +130,72 @@ class TestIDCClient(unittest.TestCase):
         self.assertIsNotNone(df)
 
     def test_download_from_aws_manifest(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            self.client.download_from_manifest(
-                manifestFile="./study_manifest_aws.s5cmd", downloadDir=temp_dir
-            )
+        # Define the values for each optional parameter
+        quiet_values = [True, False]
+        validate_manifest_values = [True, False]
+        show_progress_bar_values = [True, False]
+        use_s5cmd_sync_dry_run_values = [True, False]
 
-            self.assertEqual(len(os.listdir(temp_dir)), 15)
+        # Generate all combinations of optional parameters
+        combinations = product(
+            quiet_values,
+            validate_manifest_values,
+            show_progress_bar_values,
+            use_s5cmd_sync_dry_run_values,
+        )
+
+        # Test each combination
+        for (
+            quiet,
+            validate_manifest,
+            show_progress_bar,
+            use_s5cmd_sync_dry_run,
+        ) in combinations:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self.client.download_from_manifest(
+                    manifestFile="./study_manifest_aws.s5cmd",
+                    downloadDir=temp_dir,
+                    quiet=quiet,
+                    validate_manifest=validate_manifest,
+                    show_progress_bar=show_progress_bar,
+                    use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+                )
+
+                self.assertEqual(len(os.listdir(temp_dir)), 15)
 
     def test_download_from_gcp_manifest(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            self.client.download_from_manifest(
-                manifestFile="./study_manifest_gcs.s5cmd", downloadDir=temp_dir
-            )
+        # Define the values for each optional parameter
+        quiet_values = [True, False]
+        validate_manifest_values = [True, False]
+        show_progress_bar_values = [True, False]
+        use_s5cmd_sync_dry_run_values = [True, False]
 
-            self.assertEqual(len(os.listdir(temp_dir)), 15)
+        # Generate all combinations of optional parameters
+        combinations = product(
+            quiet_values,
+            validate_manifest_values,
+            show_progress_bar_values,
+            use_s5cmd_sync_dry_run_values,
+        )
+
+        # Test each combination
+        for (
+            quiet,
+            validate_manifest,
+            show_progress_bar,
+            use_s5cmd_sync_dry_run,
+        ) in combinations:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self.client.download_from_manifest(
+                    manifestFile="./study_manifest_gcs.s5cmd",
+                    downloadDir=temp_dir,
+                    quiet=quiet,
+                    validate_manifest=validate_manifest,
+                    show_progress_bar=show_progress_bar,
+                    use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+                )
+
+                self.assertEqual(len(os.listdir(temp_dir)), 15)
 
 
 if __name__ == "__main__":

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -62,6 +62,27 @@ class TestIDCClient(unittest.TestCase):
         self.assertIsNotNone(studies)
 
     def test_get_series(self):
+        """
+        Query used for selecting the smallest series/studies:
+
+        SELECT
+            StudyInstanceUID,
+            ARRAY_AGG(DISTINCT(collection_id)) AS collection,
+            ARRAY_AGG(DISTINCT(series_aws_url)) AS aws_url,
+            ARRAY_AGG(DISTINCT(series_gcs_url)) AS gcs_url,
+            COUNT(DISTINCT(SOPInstanceUID)) AS num_instances,
+            SUM(instance_size) AS series_size
+        FROM
+            `bigquery-public-data.idc_current.dicom_all`
+        GROUP BY
+            StudyInstanceUID
+        HAVING
+            num_instances > 2
+        ORDER BY
+            series_size asc
+        LIMIT
+            10
+        """
         series = self.client.get_dicom_series(
             studyInstanceUID="1.3.6.1.4.1.14519.5.2.1.6279.6001.175012972118199124641098335511",
             outputFormat="list",

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -82,7 +82,7 @@ class TestIDCClient(unittest.TestCase):
     def test_download_dicom_series(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.client.download_dicom_series(
-                seriesInstanceUID="1.3.6.1.4.1.14519.5.2.1.6279.6001.141365756818074696859567662357",
+                seriesInstanceUID="1.3.6.1.4.1.14519.5.2.1.7695.1700.153974929648969296590126728101",
                 downloadDir=temp_dir,
             )
             self.assertNotEqual(len(os.listdir(temp_dir)), 0)
@@ -114,7 +114,7 @@ class TestIDCClient(unittest.TestCase):
                     downloadDir=temp_dir,
                     dry_run=dry_run,
                     patientId=None,
-                    studyInstanceUID="1.3.6.1.4.1.14519.5.2.1.6279.6001.175012972118199124641098335511",
+                    studyInstanceUID="1.3.6.1.4.1.14519.5.2.1.7695.1700.114861588187429958687900856462",
                     seriesInstanceUID=None,
                     quiet=quiet,
                     show_progress_bar=show_progress_bar,
@@ -161,7 +161,7 @@ class TestIDCClient(unittest.TestCase):
                     use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
                 )
 
-                self.assertEqual(len(os.listdir(temp_dir)), 15)
+                self.assertEqual(len(os.listdir(temp_dir)), 9)
 
     def test_download_from_gcp_manifest(self):
         # Define the values for each optional parameter
@@ -195,7 +195,41 @@ class TestIDCClient(unittest.TestCase):
                     use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
                 )
 
-                self.assertEqual(len(os.listdir(temp_dir)), 15)
+                self.assertEqual(len(os.listdir(temp_dir)), 9)
+
+    def test_download_from_bogus_manifest(self):
+        # Define the values for each optional parameter
+        quiet_values = [True, False]
+        validate_manifest_values = [True, False]
+        show_progress_bar_values = [True, False]
+        use_s5cmd_sync_dry_run_values = [True, False]
+
+        # Generate all combinations of optional parameters
+        combinations = product(
+            quiet_values,
+            validate_manifest_values,
+            show_progress_bar_values,
+            use_s5cmd_sync_dry_run_values,
+        )
+
+        # Test each combination
+        for (
+            quiet,
+            validate_manifest,
+            show_progress_bar,
+            use_s5cmd_sync_dry_run,
+        ) in combinations:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self.client.download_from_manifest(
+                    manifestFile="./study_manifest_bogus.s5cmd",
+                    downloadDir=temp_dir,
+                    quiet=quiet,
+                    validate_manifest=validate_manifest,
+                    show_progress_bar=show_progress_bar,
+                    use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+                )
+
+                self.assertEqual(len(os.listdir(temp_dir)), 0)
 
 
 if __name__ == "__main__":

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -113,14 +113,14 @@ class TestIDCClient(unittest.TestCase):
         dry_run_values = [True, False]
         quiet_values = [True, False]
         show_progress_bar_values = [True, False]
-        use_s5cmd_sync_dry_run_values = [True, False]
+        use_s5cmd_sync_values = [True, False]
 
         # Generate all combinations of optional parameters
         combinations = product(
             dry_run_values,
             quiet_values,
             show_progress_bar_values,
-            use_s5cmd_sync_dry_run_values,
+            use_s5cmd_sync_values,
         )
 
         # Test each combination
@@ -128,7 +128,7 @@ class TestIDCClient(unittest.TestCase):
             dry_run,
             quiet,
             show_progress_bar,
-            use_s5cmd_sync_dry_run,
+            use_s5cmd_sync,
         ) in combinations:
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.client.download_from_selection(
@@ -139,7 +139,7 @@ class TestIDCClient(unittest.TestCase):
                     seriesInstanceUID=None,
                     quiet=quiet,
                     show_progress_bar=show_progress_bar,
-                    use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+                    use_s5cmd_sync=use_s5cmd_sync,
                 )
 
                 if not dry_run:
@@ -155,14 +155,14 @@ class TestIDCClient(unittest.TestCase):
         quiet_values = [True, False]
         validate_manifest_values = [True, False]
         show_progress_bar_values = [True, False]
-        use_s5cmd_sync_dry_run_values = [True, False]
+        use_s5cmd_sync_values = [True, False]
 
         # Generate all combinations of optional parameters
         combinations = product(
             quiet_values,
             validate_manifest_values,
             show_progress_bar_values,
-            use_s5cmd_sync_dry_run_values,
+            use_s5cmd_sync_values,
         )
 
         # Test each combination
@@ -170,7 +170,7 @@ class TestIDCClient(unittest.TestCase):
             quiet,
             validate_manifest,
             show_progress_bar,
-            use_s5cmd_sync_dry_run,
+            use_s5cmd_sync,
         ) in combinations:
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.client.download_from_manifest(
@@ -179,7 +179,7 @@ class TestIDCClient(unittest.TestCase):
                     quiet=quiet,
                     validate_manifest=validate_manifest,
                     show_progress_bar=show_progress_bar,
-                    use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+                    use_s5cmd_sync=use_s5cmd_sync,
                 )
 
                 self.assertEqual(len(os.listdir(temp_dir)), 9)
@@ -189,14 +189,14 @@ class TestIDCClient(unittest.TestCase):
         quiet_values = [True, False]
         validate_manifest_values = [True, False]
         show_progress_bar_values = [True, False]
-        use_s5cmd_sync_dry_run_values = [True, False]
+        use_s5cmd_sync_values = [True, False]
 
         # Generate all combinations of optional parameters
         combinations = product(
             quiet_values,
             validate_manifest_values,
             show_progress_bar_values,
-            use_s5cmd_sync_dry_run_values,
+            use_s5cmd_sync_values,
         )
 
         # Test each combination
@@ -204,7 +204,7 @@ class TestIDCClient(unittest.TestCase):
             quiet,
             validate_manifest,
             show_progress_bar,
-            use_s5cmd_sync_dry_run,
+            use_s5cmd_sync,
         ) in combinations:
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.client.download_from_manifest(
@@ -213,7 +213,7 @@ class TestIDCClient(unittest.TestCase):
                     quiet=quiet,
                     validate_manifest=validate_manifest,
                     show_progress_bar=show_progress_bar,
-                    use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+                    use_s5cmd_sync=use_s5cmd_sync,
                 )
 
                 self.assertEqual(len(os.listdir(temp_dir)), 9)
@@ -223,14 +223,14 @@ class TestIDCClient(unittest.TestCase):
         quiet_values = [True, False]
         validate_manifest_values = [True, False]
         show_progress_bar_values = [True, False]
-        use_s5cmd_sync_dry_run_values = [True, False]
+        use_s5cmd_sync_values = [True, False]
 
         # Generate all combinations of optional parameters
         combinations = product(
             quiet_values,
             validate_manifest_values,
             show_progress_bar_values,
-            use_s5cmd_sync_dry_run_values,
+            use_s5cmd_sync_values,
         )
 
         # Test each combination
@@ -238,7 +238,7 @@ class TestIDCClient(unittest.TestCase):
             quiet,
             validate_manifest,
             show_progress_bar,
-            use_s5cmd_sync_dry_run,
+            use_s5cmd_sync,
         ) in combinations:
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.client.download_from_manifest(
@@ -247,7 +247,7 @@ class TestIDCClient(unittest.TestCase):
                     quiet=quiet,
                     validate_manifest=validate_manifest,
                     show_progress_bar=show_progress_bar,
-                    use_s5cmd_sync_dry_run=use_s5cmd_sync_dry_run,
+                    use_s5cmd_sync=use_s5cmd_sync,
                 )
 
                 self.assertEqual(len(os.listdir(temp_dir)), 0)

--- a/tests/study_manifest_aws.s5cmd
+++ b/tests/study_manifest_aws.s5cmd
@@ -1,6 +1,6 @@
 # To download the files in this manifest, first install s5cmd (https://github.com/peak/s5cmd),
 # then run the following command:
 # s5cmd --no-sign-request --endpoint-url https://s3.amazonaws.com run study_manifest_aws.s5cmd
-cp s3://idc-open-data/58719bbb-1356-457a-bfb6-e0bee68e05aa/* .
-cp s3://idc-open-data/f7dbee2f-1f62-466e-bba7-b79e299d03a9/* .
-cp s3://idc-open-data/e3dd4623-d4c9-4d65-8f57-be1bded184a0/* .
+cp s3://idc-open-data/28621ba9-1aca-4aab-a2a1-f6d2c3e2ab19/* .
+cp s3://idc-open-data/f0b76401-c6d1-4b61-a5fd-3fa596e6cc41/* .
+cp s3://idc-open-data/4ea3bbe6-98da-4b92-abe6-2ee18927e3c9/* .

--- a/tests/study_manifest_bogus.s5cmd
+++ b/tests/study_manifest_bogus.s5cmd
@@ -1,0 +1,4 @@
+# the URLs below are invalid and are used for test purposes only!
+cp s3://invalid-idc-open-data/28621ba9-1aca-4aab-a2a1-f6d2c3e2ab19/* .
+cp s3://invalid-idc-open-data/f0b76401-c6d1-4b61-a5fd-3fa596e6cc41/* .
+cp s3://invalid-idc-open-data/4ea3bbe6-98da-4b92-abe6-2ee18927e3c9/* .

--- a/tests/study_manifest_gcs.s5cmd
+++ b/tests/study_manifest_gcs.s5cmd
@@ -1,6 +1,6 @@
 # To download the files in this manifest, first install s5cmd (https://github.com/peak/s5cmd),
 # then run the following command:
 # s5cmd --no-sign-request --endpoint-url https://storage.googleapis.com run study_manifest_gcs.s5cmd
-cp s3://public-datasets-idc/58719bbb-1356-457a-bfb6-e0bee68e05aa/* .
-cp s3://public-datasets-idc/f7dbee2f-1f62-466e-bba7-b79e299d03a9/* .
-cp s3://public-datasets-idc/e3dd4623-d4c9-4d65-8f57-be1bded184a0/* .
+cp s3://idc-open-data/28621ba9-1aca-4aab-a2a1-f6d2c3e2ab19/* .
+cp s3://idc-open-data/f0b76401-c6d1-4b61-a5fd-3fa596e6cc41/* .
+cp s3://idc-open-data/4ea3bbe6-98da-4b92-abe6-2ee18927e3c9/* .


### PR DESCRIPTION
This PR aims to address #24 and #51

there is no way to track download sequentially as s5cmd run or cp command will be locked on a thread. so, download progress is outsourced to a thread and will run simultaneously along side download thread on both series and manifest downloader

as the index only contains aws urls, when a manifest contains gcs urls, crdc series instance uuid is extracted from aws urls and queried against the aws urls in the index to get download size. For manifest download, download size is calculated first and the progress is tracked against as a whole.

manifest validator in download from manifest is offloaded to a dedicated function that will check not only the first line but every line, and if the manifest has urls from both gcp and aws to raise an exception.

s5cmd cp is replaced with sync to gracefully avoid downloading the same data again.

get functions will now return a message that data not found for the values given for a key.

queries folder is now removed as they will persist in idc-index-data

