### PR TITLE
Switch index to parquet format

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -26,11 +26,11 @@ gcp_endpoint_url = "https://storage.googleapis.com"
 
 class IDCClient:
     def __init__(self):
-        file_path = idc_index_data.IDC_INDEX_CSV_ARCHIVE_FILEPATH
+        file_path = idc_index_data.IDC_INDEX_PARQUET_FILEPATH
 
         # Read index file
         logger.debug(f"Reading index file v{idc_index_data.__version__}")
-        self.index = pd.read_csv(file_path, dtype=str, encoding="utf-8")
+        self.index = pd.read_parquet(file_path)
         self.index = self.index.astype(str).replace("nan", "")
         self.index["series_size_MB"] = self.index["series_size_MB"].astype(float)
         self.collection_summary = self.index.groupby("collection_id").agg(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "idc-index-data",
   "pandas<2.2",
   "psutil",
+  "pyarrow",
   "s5cmd",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   'duckdb>=0.10.0',
-  "idc-index-data",
+  "idc-index-data==17.0.2",
   "pandas<2.2",
   "psutil",
   "pyarrow",


### PR DESCRIPTION
@fedorov Once https://github.com/ImagingDataCommons/idc-index-data/pull/17 is merged, and new pypi release is created,
I'll lock the data version in idc-index's pyproject.toml. This PR should then pass the tests.