### PR TITLE
fix: lock the version of idc-index-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   'duckdb>=0.10.0',
-  "idc-index-data",
+  "idc-index-data==17.0.0",
   "pandas<2.2",
   "psutil",
   "s5cmd",


### PR DESCRIPTION
without a locked version, updates and problems introduced in the releases of idc-index-data affect idc-index, and currently make the package unusable, since the former switched to Parquet, and the latter is not yet able to read Parquet files