### PR TITLE
bump idc-index-data to v18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   'duckdb>=0.10.0',
-  "idc-index-data==17.0.2",
+  "idc-index-data==18.0.0",
   "packaging",
   "pandas<2.2",
   "psutil",


### PR DESCRIPTION
Once idc-index-data to v18.0.0, we can create a new release.