### PR TITLE
enh: provide an option to download into a user defined hierarchy

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -794,7 +794,7 @@ class IDCClient:
         Args:
             output (str): The output of s5cmd sync --dry-run command.
             downloadDir (str): The directory to download the files to.
-            dirTemplate (str): A template string for the directory path.
+            dirTemplate (str): Download directory hierarchy template.
 
         Returns:
             Path: The path to the generated synced manifest file.
@@ -907,7 +907,7 @@ class IDCClient:
             quiet (bool, optional): If True, suppresses the stdout and stderr of the s5cmd command.
             show_progress_bar (bool, optional): If True, tracks the progress of download
             use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
-            dirTemplate (str): A template string for the directory path.
+            dirTemplate (str): Download directory hierarchy template.
 
         Raises:
             subprocess.CalledProcessError: If the s5cmd command fails.
@@ -1097,7 +1097,7 @@ Destination folder is not empty and sync size is less than total size. Displayin
             validate_manifest (bool, optional): If True, validates the manifest for any errors. Defaults to True.
             show_progress_bar (bool, optional): If True, tracks the progress of download
             use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
-            dirTemplate (str): A template string for the directory path. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. It can contain attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) prefixed by '%'. The following special characters can be used as connectors: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
+            dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Raises:
             ValueError: If the download directory does not exist.
@@ -1162,7 +1162,7 @@ Destination folder is not empty and sync size is less than total size. Displayin
             quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True
             show_progress_bar (bool, optional): If True, tracks the progress of download
             use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
-            dirTemplate (str): A template string for the directory path. Defaults to %collection_id/%PatientID/%Modality/%StudyInstanceUID/%SeriesInstanceUID. It can contain attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) wrapped in '%'. Special characters can be used as connectors: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). Can be disabled by None.
+            dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         """
 
@@ -1304,7 +1304,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
             quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
             show_progress_bar (bool, optional): If True, tracks the progress of download
             use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
-            dirTemplate (str): A template string for the directory path. Defaults to %collection_id/%PatientID/%Modality/%StudyInstanceUID/%SeriesInstanceUID. It can contain attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) wrapped in '%'. Special characters can be used as connectors: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). Can be disabled by None.
+            dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Returns: None
 
@@ -1342,7 +1342,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
             quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
             show_progress_bar (bool, optional): If True, tracks the progress of download
             use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
-            dirTemplate (str): A template string for the directory path. Defaults to %collection_id/%PatientID/%Modality/%StudyInstanceUID/%SeriesInstanceUID. It can contain attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) wrapped in '%'. Special characters can be used as connectors: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). Can be disabled by None.
+            dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Returns: None
 
@@ -1380,7 +1380,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
             quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
             show_progress_bar (bool, optional): If True, tracks the progress of download
             use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
-            dirTemplate (str): A template string for the directory path. Defaults to %collection_id/%PatientID/%Modality/%StudyInstanceUID/%SeriesInstanceUID. It can contain attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) wrapped in '%'. Special characters can be used as connectors: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). Can be disabled by None.
+            dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Returns: None
 
@@ -1418,7 +1418,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
             quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
             show_progress_bar (bool, optional): If True, tracks the progress of download
             use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
-            dirTemplate (str): A template string for the directory path. Defaults to %collection_id/%PatientID/%Modality/%StudyInstanceUID/%SeriesInstanceUID. It can contain attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) wrapped in '%'. Special characters can be used as connectors: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). Can be disabled by None.
+            dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Returns: None
 

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -114,6 +114,13 @@ class TestIDCClient(unittest.TestCase):
         quiet_values = [True, False]
         show_progress_bar_values = [True, False]
         use_s5cmd_sync_values = [True, False]
+        dirTemplateValues = [
+            None,
+            "%collection_id_%PatientID/%Modality-%StudyInstanceUID%SeriesInstanceUID",
+            "%collection_id%PatientID-%Modality_%StudyInstanceUID/%SeriesInstanceUID",
+            "%collection_id-%PatientID_%Modality/%StudyInstanceUID-%SeriesInstanceUID",
+            "%collection_id_%PatientID/%Modality/%StudyInstanceUID_%SeriesInstanceUID",
+        ]
 
         # Generate all combinations of optional parameters
         combinations = product(
@@ -121,6 +128,7 @@ class TestIDCClient(unittest.TestCase):
             quiet_values,
             show_progress_bar_values,
             use_s5cmd_sync_values,
+            dirTemplateValues,
         )
 
         # Test each combination
@@ -129,6 +137,7 @@ class TestIDCClient(unittest.TestCase):
             quiet,
             show_progress_bar,
             use_s5cmd_sync,
+            dirTemplate,
         ) in combinations:
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.client.download_from_selection(
@@ -140,6 +149,7 @@ class TestIDCClient(unittest.TestCase):
                     quiet=quiet,
                     show_progress_bar=show_progress_bar,
                     use_s5cmd_sync=use_s5cmd_sync,
+                    dirTemplate=dirTemplate,
                 )
 
                 if not dry_run:
@@ -156,21 +166,26 @@ class TestIDCClient(unittest.TestCase):
         validate_manifest_values = [True, False]
         show_progress_bar_values = [True, False]
         use_s5cmd_sync_values = [True, False]
-
+        dirTemplateValues = [
+            None,
+            "%collection_id/%PatientID/%Modality/%StudyInstanceUID/%SeriesInstanceUID",
+            "%collection_id%PatientID%Modality%StudyInstanceUID%SeriesInstanceUID",
+        ]
         # Generate all combinations of optional parameters
         combinations = product(
             quiet_values,
             validate_manifest_values,
             show_progress_bar_values,
             use_s5cmd_sync_values,
+            dirTemplateValues,
         )
-
         # Test each combination
         for (
             quiet,
             validate_manifest,
             show_progress_bar,
             use_s5cmd_sync,
+            dirTemplate,
         ) in combinations:
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.client.download_from_manifest(
@@ -180,9 +195,12 @@ class TestIDCClient(unittest.TestCase):
                     validate_manifest=validate_manifest,
                     show_progress_bar=show_progress_bar,
                     use_s5cmd_sync=use_s5cmd_sync,
+                    dirTemplate=dirTemplate,
                 )
 
-                self.assertEqual(len(os.listdir(temp_dir)), 9)
+                self.assertEqual(
+                    sum([len(files) for r, d, files in os.walk(temp_dir)]), 9
+                )
 
     def test_download_from_gcp_manifest(self):
         # Define the values for each optional parameter
@@ -190,13 +208,18 @@ class TestIDCClient(unittest.TestCase):
         validate_manifest_values = [True, False]
         show_progress_bar_values = [True, False]
         use_s5cmd_sync_values = [True, False]
-
+        dirTemplateValues = [
+            None,
+            "%collection_id/%PatientID/%Modality/%StudyInstanceUID/%SeriesInstanceUID",
+            "%collection_id_%PatientID_%Modality_%StudyInstanceUID_%SeriesInstanceUID",
+        ]
         # Generate all combinations of optional parameters
         combinations = product(
             quiet_values,
             validate_manifest_values,
             show_progress_bar_values,
             use_s5cmd_sync_values,
+            dirTemplateValues,
         )
 
         # Test each combination
@@ -205,6 +228,7 @@ class TestIDCClient(unittest.TestCase):
             validate_manifest,
             show_progress_bar,
             use_s5cmd_sync,
+            dirTemplate,
         ) in combinations:
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.client.download_from_manifest(
@@ -214,9 +238,12 @@ class TestIDCClient(unittest.TestCase):
                     validate_manifest=validate_manifest,
                     show_progress_bar=show_progress_bar,
                     use_s5cmd_sync=use_s5cmd_sync,
+                    dirTemplate=dirTemplate,
                 )
 
-                self.assertEqual(len(os.listdir(temp_dir)), 9)
+                self.assertEqual(
+                    sum([len(files) for r, d, files in os.walk(temp_dir)]), 9
+                )
 
     def test_download_from_bogus_manifest(self):
         # Define the values for each optional parameter

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -106,7 +106,7 @@ class TestIDCClient(unittest.TestCase):
                 seriesInstanceUID="1.3.6.1.4.1.14519.5.2.1.7695.1700.153974929648969296590126728101",
                 downloadDir=temp_dir,
             )
-            self.assertEqual(sum([len(files) for r, d, files in os.walk(temp_dir)]), 9)
+            self.assertEqual(sum([len(files) for r, d, files in os.walk(temp_dir)]), 3)
 
     def test_download_with_template(self):
         dirTemplateValues = [
@@ -124,7 +124,7 @@ class TestIDCClient(unittest.TestCase):
                     dirTemplate=template,
                 )
                 self.assertEqual(
-                    sum([len(files) for r, d, files in os.walk(temp_dir)]), 9
+                    sum([len(files) for r, d, files in os.walk(temp_dir)]), 3
                 )
 
     def test_download_from_selection(self):


### PR DESCRIPTION
addresses #22 

Default template directory is "%collection_id/%PatientID/%Modality/%StudyInstanceUID/%SeriesInstanceUID" However a user can pick and choose any of these five attributes in any order. In addition, the attributes can also be concatenated using hyphens or underscores. But attributes must begin with a percentage sign. 