### PR TITLE
bug(fix): fix reference used in get patients sql query

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -161,7 +161,7 @@ class IDCClient:
                     STRING_AGG(DISTINCT PatientSex) as PatientSex,
                     STRING_AGG(DISTINCT PatientAge) as PatientAge
                 FROM
-                    index
+                    patient_df
                 GROUP BY
                     PatientID
                 ORDER BY


### PR DESCRIPTION
As I was testing the latest index.py on SlicerIDCBrowser, I noticed that no matter which collection I select, the same patients are shown. Found that this was of incorrect reference used in the SQL query of get_patients.

In addition, the same logic that plagued get_patients affects get_dicom_studies as well, when there are nulls in seriesDescriptions or dates.

 
This PR addresses both issues