### PR TITLE
doc: Improve rendering of "early development" notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@
 
 [![Discourse Forum][discourse-forum-badge]][discourse-forum-link]
 
-<!-- SPHINX-START -->
-
-## About
-
-`idc-index` is a Python package that enables query of the basic metadata and
-download of DICOM files hosted by the
-[NCI Imaging Data Commons (IDC)](https://imaging.datacommons.cancer.gov).
-
 > [!WARNING]
 >
 > This package is in its early development stages. Its functionality and API
@@ -24,6 +16,14 @@ download of DICOM files hosted by the
 > Stay tuned for the updates and documentation, and please share your feedback
 > about it by opening issues in this repository, or by starting a discussion in
 > [IDC User forum](https://discourse.canceridc.dev/).
+
+<!-- SPHINX-START -->
+
+## About
+
+`idc-index` is a Python package that enables query of the basic metadata and
+download of DICOM files hosted by the
+[NCI Imaging Data Commons (IDC)](https://imaging.datacommons.cancer.gov).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@
 download of DICOM files hosted by the
 [NCI Imaging Data Commons (IDC)](https://imaging.datacommons.cancer.gov).
 
-👷 🚧 This package is in its early development stages. Its functionality and API
-will change. Stay tuned for the updates and documentation, and please share your
-feedback about it by opening issues in this repository, or by starting a
-discussion in [IDC User forum](https://discourse.canceridc.dev/).🚧
+> [!WARNING]
+>
+> This package is in its early development stages. Its functionality and API
+> will change.
+>
+> Stay tuned for the updates and documentation, and please share your feedback
+> about it by opening issues in this repository, or by starting a discussion in
+> [IDC User forum](https://discourse.canceridc.dev/).
 
 ## Usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,19 @@
 ```{toctree}
 :maxdepth: 2
 :hidden:
-
 ```
+
+:::{warning}
+
+This package is in its early development stages. Its functionality and API will
+change.
+
+Stay tuned for the updates and documentation, and please share your feedback
+about it by opening issues at the
+[idc-index](https://github.com/ImagingDataCommons/idc-index) repository, or by
+starting a discussion in [IDC User forum](https://discourse.canceridc.dev/).
+
+:::
 
 ```{include} ../README.md
 :start-after: <!-- SPHINX-START -->


### PR DESCRIPTION
Switch to use of GitHub markdown admonition

See https://github.com/orgs/community/discussions/16925

| Before |After |
|--|--|
| ![image](https://github.com/ImagingDataCommons/idc-index/assets/219043/b29e57d7-357e-45c1-a2f2-eb26b8a1a27e) | ![image](https://github.com/ImagingDataCommons/idc-index/assets/219043/d579b47b-baae-47a2-bc15-ab7179d1084d) |
