### PR TITLE
Additional API docstrings fixes

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -141,7 +141,7 @@ class IDCClient:
             collection_id (str or list[str]): The collection id or list of collection ids. This should be in lower case separated by underscores.
                 For example, 'pdmr_texture_analysis'. or ['pdmr_texture_analysis','nlst']
 
-            outputFormat (str, optional): The format in which to return the patient IDs. Available options are 'dict',
+            outputFormat (str): The format in which to return the patient IDs. Available options are 'dict',
                 'df', and 'list'. Default is 'dict'.
 
         Returns:
@@ -192,7 +192,7 @@ class IDCClient:
         Args:
             patientId (str or list of str): The patient Id or a list of patient Ids.
 
-            outputFormat (str, optional): The format in which to return the studies. Available options are 'dict',
+            outputFormat (str): The format in which to return the studies. Available options are 'dict',
                 'df', and 'list'. Default is 'dict'.
 
         Returns:
@@ -245,7 +245,7 @@ class IDCClient:
         Args:
             studyInstanceUID (str or list of str): The DICOM StudyInstanceUID or a list of StudyInstanceUIDs.
 
-            outputFormat (str, optional): The format in which to return the series. Available options are 'dict',
+            outputFormat (str): The format in which to return the series. Available options are 'dict',
                 'df', and 'list'. Default is 'dict'.
 
         Returns:
@@ -477,9 +477,9 @@ class IDCClient:
         Args:
             manifestFile (str): The path to the manifest file.
             downloadDir (str): The path to the download directory.
-            validate_manifest (bool, optional): If True, validates the manifest for any errors. Defaults to True.
-            show_progress_bar (bool, optional): If True, tracks the progress of download
-            use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
+            validate_manifest (bool): If True, validates the manifest for any errors. Defaults to True.
+            show_progress_bar (bool): If True, tracks the progress of download
+            use_s5cmd_sync (bool): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
             dirTemplate (str): A template string for the directory path. Must start with %. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT. It can contain attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) wrapped in '%'. Special characters can be used as connectors: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). Can be disabled by None.
 
         Returns:
@@ -896,9 +896,9 @@ class IDCClient:
             manifest_file (str): The path to the manifest file listing the files to be downloaded.
             total_size (float): The total size of the files to be downloaded in MB.
             downloadDir (str): The local directory where the files will be downloaded.
-            quiet (bool, optional): If True, suppresses the stdout and stderr of the s5cmd command.
-            show_progress_bar (bool, optional): If True, tracks the progress of download
-            use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
+            quiet (bool): If True, suppresses the stdout and stderr of the s5cmd command.
+            show_progress_bar (bool): If True, tracks the progress of download
+            use_s5cmd_sync (bool): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
             dirTemplate (str): Download directory hierarchy template.
 
         Raises:
@@ -1085,10 +1085,10 @@ Destination folder is not empty and sync size is less than total size. Displayin
         Args:
             manifestFile (str): The path to the manifest file.
             downloadDir (str): The directory to download the files to.
-            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
-            validate_manifest (bool, optional): If True, validates the manifest for any errors. Defaults to True.
-            show_progress_bar (bool, optional): If True, tracks the progress of download
-            use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
+            quiet (bool): If True, suppresses the output of the subprocess. Defaults to True.
+            validate_manifest (bool): If True, validates the manifest for any errors. Defaults to True.
+            show_progress_bar (bool): If True, tracks the progress of download
+            use_s5cmd_sync (bool): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
             dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Raises:
@@ -1151,9 +1151,9 @@ Destination folder is not empty and sync size is less than total size. Displayin
             patientId: string or list of strings containing the values of PatientID to filter by
             studyInstanceUID: string or list of strings containing the values of DICOM StudyInstanceUID to filter by
             seriesInstanceUID: string or list of strings containing the values of DICOM SeriesInstanceUID to filter by
-            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True
-            show_progress_bar (bool, optional): If True, tracks the progress of download
-            use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
+            quiet (bool): If True, suppresses the output of the subprocess. Defaults to True
+            show_progress_bar (bool): If True, tracks the progress of download
+            use_s5cmd_sync (bool): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
             dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         """
@@ -1290,9 +1290,9 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
             seriesInstanceUID: string or list of strings containing the values of DICOM SeriesInstanceUID to filter by
             downloadDir: string containing the path to the directory to download the files to
             dry_run: calculates the size of the cohort but download does not start
-            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
-            show_progress_bar (bool, optional): If True, tracks the progress of download
-            use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
+            quiet (bool): If True, suppresses the output of the subprocess. Defaults to True.
+            show_progress_bar (bool): If True, tracks the progress of download
+            use_s5cmd_sync (bool): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
             dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Returns: None
@@ -1328,9 +1328,9 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
             studyInstanceUID: string or list of strings containing the values of DICOM studyInstanceUID to filter by
             downloadDir: string containing the path to the directory to download the files to
             dry_run: calculates the size of the cohort but download does not start
-            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
-            show_progress_bar (bool, optional): If True, tracks the progress of download
-            use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
+            quiet (bool): If True, suppresses the output of the subprocess. Defaults to True.
+            show_progress_bar (bool): If True, tracks the progress of download
+            use_s5cmd_sync (bool): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
             dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Returns: None
@@ -1366,9 +1366,9 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
             patientId: string or list of strings containing the values of DICOM patientId to filter by
             downloadDir: string containing the path to the directory to download the files to
             dry_run: calculates the size of the cohort but download does not start
-            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
-            show_progress_bar (bool, optional): If True, tracks the progress of download
-            use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
+            quiet (bool): If True, suppresses the output of the subprocess. Defaults to True.
+            show_progress_bar (bool): If True, tracks the progress of download
+            use_s5cmd_sync (bool): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
             dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Returns: None
@@ -1404,9 +1404,9 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
             collection_id: string or list of strings containing the values of DICOM patientId to filter by
             downloadDir: string containing the path to the directory to download the files to
             dry_run: calculates the size of the cohort but download does not start
-            quiet (bool, optional): If True, suppresses the output of the subprocess. Defaults to True.
-            show_progress_bar (bool, optional): If True, tracks the progress of download
-            use_s5cmd_sync (bool, optional): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
+            quiet (bool): If True, suppresses the output of the subprocess. Defaults to True.
+            show_progress_bar (bool): If True, tracks the progress of download
+            use_s5cmd_sync (bool): If True, will use s5cmd sync operation instead of cp when downloadDirectory is not empty; this can significantly improve the download speed if the content is partially downloaded
             dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
 
         Returns: None

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -138,11 +138,11 @@ class IDCClient:
         Gets the patients in a collection.
 
         Args:
-            collection_id (str or a list of str): The collection id or list of collection ids. This should be in lower case separated by underscores.
-                                For example, 'pdmr_texture_analysis'. or ['pdmr_texture_analysis','nlst']
+            collection_id (str or list[str]): The collection id or list of collection ids. This should be in lower case separated by underscores.
+                For example, 'pdmr_texture_analysis'. or ['pdmr_texture_analysis','nlst']
 
             outputFormat (str, optional): The format in which to return the patient IDs. Available options are 'dict',
-                                        'df', and 'list'. Default is 'dict'.
+                'df', and 'list'. Default is 'dict'.
 
         Returns:
             dict or pandas.DataFrame or list: Patient IDs in the requested output format. By default, it returns a dictionary.
@@ -193,7 +193,7 @@ class IDCClient:
             patientId (str or list of str): The patient Id or a list of patient Ids.
 
             outputFormat (str, optional): The format in which to return the studies. Available options are 'dict',
-                                        'df', and 'list'. Default is 'dict'.
+                'df', and 'list'. Default is 'dict'.
 
         Returns:
             dict or pandas.DataFrame or list: Studies in the requested output format. By default, it returns a dictionary.
@@ -246,7 +246,7 @@ class IDCClient:
             studyInstanceUID (str or list of str): The DICOM StudyInstanceUID or a list of StudyInstanceUIDs.
 
             outputFormat (str, optional): The format in which to return the series. Available options are 'dict',
-                                        'df', and 'list'. Default is 'dict'.
+                'df', and 'list'. Default is 'dict'.
 
         Returns:
             dict or pandas.DataFrame or list: Series in the requested output format. By default, it returns a dictionary.
@@ -369,13 +369,13 @@ class IDCClient:
 
         Args:
             SeriesInstanceUID: string containing the value of DICOM SeriesInstanceUID for a series
-            available in IDC
+                available in IDC
 
             StudyInstanceUID: string containing the value of DICOM SeriesInstanceUID for a series
-            available in IDC
+                available in IDC
 
             viewer_selector: string containing the name of the viewer to use. Must be one of the following:
-            ohif_v2, ohif_v3, or slim. If not provided, default viewers will be used.
+                ohif_v2, ohif_v3, or slim. If not provided, default viewers will be used.
 
         Returns:
             string containing the IDC viewer URL for the given SeriesInstanceUID

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -1435,7 +1435,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
             pandas dataframe containing the results of the query
 
         Raises:
-            any exception that duckdb.query() raises
+            duckdb.Error: any exception that duckdb.query() raises
         """
 
         index = self.index


### PR DESCRIPTION
This is a follow-up of https://github.com/ImagingDataCommons/idc-index/pull/83

### Fix parsing of list of argument used in docstrings 

Update indentation to fix warnings like the following:

```
/path/to/index.py:docstring of idc_index.index.IDCClient.get_viewer_URL:1: WARNING: py:class reference target not found: available in
/path/to/index.py:docstring of idc_index.index.IDCClient.get_viewer_URL:1: WARNING: py:class reference target not found: or slim. If not
/path/to/index.py:docstring of idc_index.index.IDCClient.get_viewer_URL:1: WARNING: py:class reference target not found: default viewers will be
```

Fix the following warning using "list[str]" instead of "a list of str"

```
/path/to/index.py:docstring of idc_index.index.IDCClient.get_patients:1: WARNING: py:class reference target not found: a list
```

### Remove unsupported "optional" hint from docstrings 

Remove the use of the "optional" hint from the docstrings to address the following Sphinx warnings. The "optional" hint is not supported by Sphinx and was inconsistently specified for keyword arguments with default values.

```
[...]
/path/to/index.py:docstring of idc_index.index.IDCClient.download_from_selection:1: WARNING: py:class reference target not found: optional
/path/to/index.py:docstring of idc_index.index.IDCClient.get_dicom_series:1: WARNING: py:class reference target not found: optional
/path/to/index.py:docstring of idc_index.index.IDCClient.get_dicom_studies:1: WARNING: py:class reference target not found: optional
/path/to/index.py:docstring of idc_index.index.IDCClient.get_patients:1: WARNING: py:class reference target not found: optional
[...]
```

For more details, see the related Sphinx issue:
* sphinx-doc/sphinx#11376


###  Fix description of exception associated with "sql_query" function 

Explicitly reference the name of exception object.

Note that at the time of this commit, inter-sphinx mapping was not available for duckdb:
* duckdb/duckdb#12115

> [!WARNING]
>
> As expected, the last warning reported when building the documentation is then the following:
>
> ```
> /path/to/index.py:docstring of idc_index.index.IDCClient.sql_query:1: WARNING: py:exc reference target not found: duckdb.Error
```