### PR TITLE
enh: add double quotes before paths so spaced paths can work

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -11,6 +11,7 @@ import time
 from importlib.metadata import distribution
 from pathlib import Path
 
+import csv
 import duckdb
 import idc_index_data
 import pandas as pd
@@ -690,20 +691,29 @@ class IDCClient:
             if use_s5cmd_sync and len(os.listdir(downloadDir)) != 0:
                 if dirTemplate is not None:
                     merged_df["s5cmd_cmd"] = (
-                        "sync " + merged_df["s3_url"] + " " + merged_df["path"]
+                        "sync "
+                        + merged_df["s3_url"]
+                        + " "
+                        + '"'
+                        + merged_df["path"]
+                        + '"'
                     )
                 else:
                     merged_df["s5cmd_cmd"] = (
-                        "sync " + merged_df["s3_url"] + " " + downloadDir
+                        "sync " + merged_df["s3_url"] + " " + '"' + downloadDir + '"'
                     )
             elif dirTemplate is not None:
                 merged_df["s5cmd_cmd"] = (
-                    "cp " + merged_df["s3_url"] + " " + merged_df["path"]
+                    "cp " + merged_df["s3_url"] + " " + '"' + merged_df["path"] + '"'
                 )
             else:
-                merged_df["s5cmd_cmd"] = "cp " + merged_df["s3_url"] + " " + downloadDir
+                merged_df["s5cmd_cmd"] = (
+                    "cp " + merged_df["s3_url"] + " " + '"' + downloadDir + '"'
+                )
 
-            merged_df["s5cmd_cmd"].to_csv(temp_manifest_file, header=False, index=False)
+            merged_df["s5cmd_cmd"].to_csv(
+                temp_manifest_file, header=False, index=False, quoting=csv.QUOTE_NONE
+            )
             logger.info("Parsing the manifest is finished. Download will begin soon")
 
         if dirTemplate is not None:
@@ -918,15 +928,17 @@ class IDCClient:
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as synced_manifest:
             if dirTemplate is not None:
                 synced_df["s5cmd_cmd"] = (
-                    "sync " + synced_df["s3_url"] + " " + synced_df["path"]
+                    "sync " + synced_df["s3_url"] + " " + '"' + synced_df["path"] + '"'
                 )
                 list_of_directories = synced_df.path.to_list()
             else:
                 synced_df["s5cmd_cmd"] = (
-                    "sync " + synced_df["s3_url"] + " " + downloadDir
+                    "sync " + synced_df["s3_url"] + " " + '"' + downloadDir + '"'
                 )
                 list_of_directories = [downloadDir]
-            synced_df["s5cmd_cmd"].to_csv(synced_manifest, header=False, index=False)
+            synced_df["s5cmd_cmd"].to_csv(
+                synced_manifest, header=False, index=False, quoting=csv.QUOTE_NONE
+            )
             logger.info("Parsing the s5cmd sync dry run output finished")
         return Path(synced_manifest.name), sync_size_rounded, list_of_directories
 
@@ -1387,21 +1399,28 @@ Destination folder is not empty and sync size is less than total size. Displayin
             if use_s5cmd_sync and len(os.listdir(downloadDir)) != 0:
                 if dirTemplate is not None:
                     result_df["s5cmd_cmd"] = (
-                        "sync " + result_df["series_aws_url"] + " " + result_df["path"]
+                        "sync "
+                        + result_df["series_aws_url"]
+                        + ' "'
+                        + result_df["path"]
+                        + '"'
                     )
                 else:
                     result_df["s5cmd_cmd"] = (
-                        "sync " + result_df["series_aws_url"] + " " + downloadDir
+                        "sync " + result_df["series_aws_url"] + ' "' + downloadDir + '"'
                     )
             elif dirTemplate is not None:
                 result_df["s5cmd_cmd"] = (
-                    "cp " + result_df["series_aws_url"] + " " + result_df["path"]
+                    "cp " + result_df["series_aws_url"] + ' "' + result_df["path"] + '"'
                 )
             else:
                 result_df["s5cmd_cmd"] = (
-                    "cp " + result_df["series_aws_url"] + " " + downloadDir
+                    "cp " + result_df["series_aws_url"] + ' "' + downloadDir + '"'
                 )
-            result_df["s5cmd_cmd"].to_csv(manifest_file, header=False, index=False)
+
+            result_df["s5cmd_cmd"].to_csv(
+                manifest_file, header=False, index=False, quoting=csv.QUOTE_NONE
+            )
             if dirTemplate is not None:
                 list_of_directories = result_df.path.to_list()
             else:

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -11,7 +11,6 @@ import time
 from importlib.metadata import distribution
 from pathlib import Path
 
-import csv
 import duckdb
 import idc_index_data
 import pandas as pd
@@ -711,9 +710,11 @@ class IDCClient:
                     "cp " + merged_df["s3_url"] + " " + '"' + downloadDir + '"'
                 )
 
-            merged_df["s5cmd_cmd"].to_csv(
-                temp_manifest_file, header=False, index=False, quoting=csv.QUOTE_NONE
-            )
+            # Combine all commands into a single string with newline separators
+            commands = "\n".join(merged_df["s5cmd_cmd"])
+
+            temp_manifest_file.write(commands)
+
             logger.info("Parsing the manifest is finished. Download will begin soon")
 
         if dirTemplate is not None:
@@ -936,9 +937,11 @@ class IDCClient:
                     "sync " + synced_df["s3_url"] + " " + '"' + downloadDir + '"'
                 )
                 list_of_directories = [downloadDir]
-            synced_df["s5cmd_cmd"].to_csv(
-                synced_manifest, header=False, index=False, quoting=csv.QUOTE_NONE
-            )
+                # Combine all commands into a single string with newline separators
+            commands = "\n".join(synced_df["s5cmd_cmd"])
+
+            synced_manifest.write(commands)
+
             logger.info("Parsing the s5cmd sync dry run output finished")
         return Path(synced_manifest.name), sync_size_rounded, list_of_directories
 
@@ -1418,9 +1421,11 @@ Destination folder is not empty and sync size is less than total size. Displayin
                     "cp " + result_df["series_aws_url"] + ' "' + downloadDir + '"'
                 )
 
-            result_df["s5cmd_cmd"].to_csv(
-                manifest_file, header=False, index=False, quoting=csv.QUOTE_NONE
-            )
+            # Combine all commands into a single string with newline separators
+            commands = "\n".join(result_df["s5cmd_cmd"])
+
+            manifest_file.write(commands)
+
             if dirTemplate is not None:
                 list_of_directories = result_df.path.to_list()
             else:


### PR DESCRIPTION
Currently whenever a download path consists of spaces, s5cmd command does not work. 

![image](https://github.com/ImagingDataCommons/idc-index/assets/115020590/251aeed8-9081-4615-9b79-c8ffda4c706d)

But to force it, we must include the path containing spaces in double quotes. The issue was first encountered in SlicerIDCBrowser. https://github.com/ImagingDataCommons/SlicerIDCBrowser/issues/39

This PR will fix https://github.com/ImagingDataCommons/SlicerIDCBrowser/issues/39