### PR TITLE
Add IDCClient() singleton feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ $ pip install --upgrade idc-index
 Instantiate `IDCClient`, which provides the interface for main operations.
 
 ```python
-from idc_index import index
+from idc_index import IDCClient
 
-client = index.IDCClient()
+client = IDCClient.client()
 ```
 
 You can use [IDC Portal](https://imaging.datacommons.cancer.gov/explore) to

--- a/idc_index/__init__.py
+++ b/idc_index/__init__.py
@@ -9,5 +9,3 @@ from __future__ import annotations
 from ._version import version as __version__
 
 __all__ = ["__version__"]
-
-from .index import IDCClient

--- a/idc_index/__init__.py
+++ b/idc_index/__init__.py
@@ -9,3 +9,7 @@ from __future__ import annotations
 from ._version import version as __version__
 
 __all__ = ["__version__"]
+
+from .index import IDCClient
+
+_ = IDCClient

--- a/idc_index/__init__.py
+++ b/idc_index/__init__.py
@@ -9,3 +9,5 @@ from __future__ import annotations
 from ._version import version as __version__
 
 __all__ = ["__version__"]
+
+from .index import IDCClient

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -39,6 +39,25 @@ class IDCClient:
     CITATION_FORMAT_JSON = "application/vnd.citationstyles.csl+json"
     CITATION_FORMAT_BIBTEX = "application/x-bibtex"
 
+
+    # Singleton pattern
+    # NOTE: In the future, one may want to use multiple clients e.g. for sub-datasets so a attribute-singleton as shown bewlo seems a better option.
+    # _instance: IDCClient
+    # def __new__(cls):
+    #     if not hasattr(cls, "_instance") or getattr(cls, "_instance") is None:
+    #         instance = super(IDCClient, cls).__new__(cls)
+    #         setattr(cls, "_instance", instance)
+    #     return cls._instance
+
+    _client: IDCClient
+
+    @classmethod
+    def client(cls) -> IDCClient:
+        if not hasattr(cls, "_client") or getattr(cls, "_client") is None:
+            setattr(cls, '_client', IDCClient())
+
+        return cls._client
+
     def __init__(self):
         file_path = idc_index_data.IDC_INDEX_PARQUET_FILEPATH
 

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -39,7 +39,6 @@ class IDCClient:
     CITATION_FORMAT_JSON = "application/vnd.citationstyles.csl+json"
     CITATION_FORMAT_BIBTEX = "application/x-bibtex"
 
-
     # Singleton pattern
     # NOTE: In the future, one may want to use multiple clients e.g. for sub-datasets so a attribute-singleton as shown bewlo seems a better option.
     # _instance: IDCClient
@@ -54,7 +53,7 @@ class IDCClient:
     @classmethod
     def client(cls) -> IDCClient:
         if not hasattr(cls, "_client") or getattr(cls, "_client") is None:
-            setattr(cls, '_client', IDCClient())
+            setattr(cls, "_client", IDCClient())
 
         return cls._client
 

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -424,11 +424,10 @@ class TestIDCClient(unittest.TestCase):
             assert len(os.listdir(temp_dir)) != 0
 
     def test_singleton_attribute(self):
-        
         # singleton, initialized on first use
         i1 = IDCClient.client()
         i2 = IDCClient.client()
-        
+
         # new instances created via constructor (through init)
         i3 = IDCClient()
         i4 = self.client
@@ -452,7 +451,7 @@ class TestIDCClient(unittest.TestCase):
         assert isinstance(i2, IDCClient)
         assert isinstance(i3, IDCClient)
         assert isinstance(i4, IDCClient)
-        
+
     def test_cli_download(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -461,6 +460,7 @@ class TestIDCClient(unittest.TestCase):
                 ["1.3.6.1.4.1.14519.5.2.1.7695.1700.114861588187429958687900856462"],
             )
             assert len(os.listdir(Path.cwd())) != 0
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -9,7 +9,7 @@ from itertools import product
 import pandas as pd
 import pytest
 from click.testing import CliRunner
-from idc_index import cli, index
+from idc_index import IDCClient, cli
 
 # Run tests using the following command from the root of the repository:
 # python -m unittest -vv tests/idcindex.py
@@ -24,7 +24,7 @@ def _change_test_dir(request, monkeypatch):
 
 class TestIDCClient(unittest.TestCase):
     def setUp(self):
-        self.client = index.IDCClient()
+        self.client = IDCClient()
         self.download_from_manifest = cli.download_from_manifest
         self.download_from_selection = cli.download_from_selection
 
@@ -420,6 +420,42 @@ class TestIDCClient(unittest.TestCase):
                 ],
             )
             assert len(os.listdir(temp_dir)) != 0
+
+    # def test_singleton(self):
+    #     i1 = IDCClient()
+    #     i2 = IDCClient()
+
+    #     assert i1 == i2
+
+    def test_singleton_attribute(self):
+        
+        # singleton, initialized on first use
+        i1 = IDCClient.client()
+        i2 = IDCClient.client()
+        
+        # new instances created via constructor (through init)
+        i3 = IDCClient()
+        i4 = self.client
+
+        # all must be not none
+        assert i1 is not None
+        assert i2 is not None
+        assert i3 is not None
+        assert i4 is not None
+
+        # singletons must return the same instance
+        assert i1 == i2
+
+        # new instances must be different
+        assert i1 != i3
+        assert i1 != i4
+        assert i3 != i4
+
+        # all must be instances of IDCClient
+        assert isinstance(i1, IDCClient)
+        assert isinstance(i2, IDCClient)
+        assert isinstance(i3, IDCClient)
+        assert isinstance(i4, IDCClient)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
No need for a global `client = IDCClient()` call, instead `IDCClient.client()` can be used directly. Upon first call a new IDCClient instance will be initialized and reused for all following calls. 