### PR TITLE
ENH: improve error reporting for unrecognized items from the manifest

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -625,14 +625,14 @@ class IDCClient:
         endpoint_to_use = None
 
         # Check if any crdc_series_uuid are not found in the index
-        if not merged_df["crdc_series_uuid_match"].all():
+        if not all(merged_df["crdc_series_uuid_match"]):
             missing_manifest_cp_cmds = merged_df.loc[
                 ~merged_df["crdc_series_uuid_match"], "manifest_cp_cmd"
             ]
             logger.error(
                 "The following manifest copy commands are not recognized as referencing any associated series in the index.\n"
                 "This means either these commands are invalid, or they may correspond to files available in a release of IDC\n"
-                f"prior to {self.get_idc_version()}. The corresponding files will not be downloaded.\n"
+                f"different from {self.get_idc_version()} used in this version of idc-index. The corresponding files will not be downloaded.\n"
             )
             logger.error("\n" + "\n".join(missing_manifest_cp_cmds.tolist()))
 

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -461,6 +461,28 @@ class TestIDCClient(unittest.TestCase):
             )
             assert len(os.listdir(Path.cwd())) != 0
 
+    def test_prior_version_manifest(self):
+        c = IDCClient()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            (
+                total_size,
+                endpoint_to_use,
+                temp_manifest_file,
+                list_of_directories,
+            ) = c._validate_update_manifest_and_get_download_size(
+                "./prior_version_manifest.s5cmd",
+                temp_dir,
+                True,
+                False,
+                IDCClient.DOWNLOAD_HIERARCHY_DEFAULT,
+            )
+
+            # TODO: once issue https://github.com/ImagingDataCommons/idc-index/issues/100
+            # is fully resolved, the manifest below should not be empty, and this test should be updated
+            # with count equal to 5
+            with open(temp_manifest_file) as file:
+                assert len(file.readlines()) == 0
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/prior_version_manifest.s5cmd
+++ b/tests/prior_version_manifest.s5cmd
@@ -1,0 +1,5 @@
+cp s3://idc-open-data/040fd3e1-0088-4bfd-8439-55e3c5d80a56/*  .
+cp s3://idc-open-data/04553d0f-1af9-414d-b631-cc31624aced5/*  .
+cp s3://idc-open-data/068346bf-16ef-4e45-87bf-87feb576a21c/*  .
+cp s3://idc-open-data/07908d47-5e85-45f3-9649-79c15f606f52/*  .
+cp s3://idc-open-data/099d180f-1d79-402d-abad-bfd8e2736b04/*  .


### PR DESCRIPTION
Re #100

Whenever a crdc_series_uuid from the manifest is not matched to those known to the index, provide error message informing the user of what could be the reasons. Fixed error checking for unrecognized items in the validation function. Report unrecognized items independently of whether validation is requested or not.