### PR TITLE
fix: s5cmd sync logic

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -1518,6 +1518,7 @@ not be accurate."""
                 SELECT
                     series_aws_url,
                     REGEXP_EXTRACT(series_aws_url, '(?:.*?\\/){{3}}([^\\/?#]+)', 1) index_crdc_series_uuid,
+                    series_size_MB,
                     {hierarchy} as path
                 FROM
                     temp

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -1507,7 +1507,9 @@ not be accurate."""
                 downloadDir=downloadDir,
                 dirTemplate=dirTemplate,
             )
-            sql = f"""
+        else:
+            hierarchy = f"CONCAT('{downloadDir}')"
+        sql = f"""
                 WITH temp as
                     (
                         SELECT
@@ -1525,9 +1527,9 @@ not be accurate."""
                 JOIN
                     index using (seriesInstanceUID)
                 """
-            result_df = self.sql_query(sql)
-            # Download the files
-            # make temporary file to store the list of files to download
+        result_df = self.sql_query(sql)
+        # Download the files
+        # make temporary file to store the list of files to download
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as manifest_file:
             if use_s5cmd_sync and len(os.listdir(downloadDir)) != 0:
                 if dirTemplate is not None:

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -463,25 +463,17 @@ class TestIDCClient(unittest.TestCase):
 
     def test_prior_version_manifest(self):
         c = IDCClient()
-        with tempfile.TemporaryDirectory() as temp_dir:
-            (
-                total_size,
-                endpoint_to_use,
-                temp_manifest_file,
-                list_of_directories,
-            ) = c._validate_update_manifest_and_get_download_size(
-                "./prior_version_manifest.s5cmd",
-                temp_dir,
-                True,
-                False,
-                IDCClient.DOWNLOAD_HIERARCHY_DEFAULT,
-            )
 
-            # TODO: once issue https://github.com/ImagingDataCommons/idc-index/issues/100
-            # is fully resolved, the manifest below should not be empty, and this test should be updated
-            # with count equal to 5
-            with open(temp_manifest_file) as file:
-                assert len(file.readlines()) == 5
+        with tempfile.TemporaryDirectory() as temp_dir:
+            c.download_from_manifest(
+                manifestFile="./prior_version_manifest.s5cmd",
+                downloadDir=temp_dir,
+                quiet=True,
+                validate_manifest=True,
+                show_progress_bar=True,
+                use_s5cmd_sync=False,
+            )
+            self.assertNotEqual(len(os.listdir(temp_dir)), 0)
 
     def test_list_indices(self):
         i = IDCClient()

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -462,18 +462,47 @@ class TestIDCClient(unittest.TestCase):
             assert len(os.listdir(Path.cwd())) != 0
 
     def test_prior_version_manifest(self):
-        c = IDCClient()
+        # Define the values for each optional parameter
+        quiet_values = [True, False]
+        validate_manifest_values = [True, False]
+        show_progress_bar_values = [True, False]
+        use_s5cmd_sync_values = [True, False]
+        dirTemplateValues = [
+            None,
+            "%collection_id/%PatientID/%Modality/%StudyInstanceUID/%SeriesInstanceUID",
+            "%collection_id_%PatientID_%Modality_%StudyInstanceUID_%SeriesInstanceUID",
+        ]
+        # Generate all combinations of optional parameters
+        combinations = product(
+            quiet_values,
+            validate_manifest_values,
+            show_progress_bar_values,
+            use_s5cmd_sync_values,
+            dirTemplateValues,
+        )
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            c.download_from_manifest(
-                manifestFile="./prior_version_manifest.s5cmd",
-                downloadDir=temp_dir,
-                quiet=True,
-                validate_manifest=True,
-                show_progress_bar=True,
-                use_s5cmd_sync=False,
-            )
-            self.assertNotEqual(len(os.listdir(temp_dir)), 0)
+        # Test each combination
+        for (
+            quiet,
+            validate_manifest,
+            show_progress_bar,
+            use_s5cmd_sync,
+            dirTemplate,
+        ) in combinations:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self.client.download_from_manifest(
+                    manifestFile="./prior_version_manifest.s5cmd",
+                    downloadDir=temp_dir,
+                    quiet=quiet,
+                    validate_manifest=validate_manifest,
+                    show_progress_bar=show_progress_bar,
+                    use_s5cmd_sync=use_s5cmd_sync,
+                    dirTemplate=dirTemplate,
+                )
+
+                self.assertEqual(
+                    sum([len(files) for r, d, files in os.walk(temp_dir)]), 5
+                )
 
     def test_list_indices(self):
         i = IDCClient()

--- a/tests/prior_version_manifest.s5cmd
+++ b/tests/prior_version_manifest.s5cmd
@@ -1,5 +1,5 @@
-cp s3://idc-open-data/040fd3e1-0088-4bfd-8439-55e3c5d80a56/*  .
-cp s3://idc-open-data/04553d0f-1af9-414d-b631-cc31624aced5/*  .
-cp s3://idc-open-data/068346bf-16ef-4e45-87bf-87feb576a21c/*  .
-cp s3://idc-open-data/07908d47-5e85-45f3-9649-79c15f606f52/*  .
-cp s3://idc-open-data/099d180f-1d79-402d-abad-bfd8e2736b04/*  .
+cp s3://idc-open-data/2f77262c-3a4a-4e5a-bdc0-056dc2837f15/* .
+cp s3://idc-open-data/35459457-bd4c-4eef-9579-47f12fc6928e/*  .
+cp s3://idc-open-data/9c9ab2bf-c784-4658-b0f9-d2e4b33f2dbf/*  .
+cp s3://idc-open-data/312788ec-8739-4e56-a857-efcab92b20ed/* .
+cp s3://idc-open-data/c27b80c9-0e90-416b-8eca-0b20bc0cf8e2/*  .


### PR DESCRIPTION
completes #100 

- fixes and improves logic of s5cmd sync download by utilizing validation results 

- picks 5 smallest series from previous idc versions

- tests prior versions data rigorosly with all combinations of optional parameters

may be better to create a new issue to support this https://github.com/ImagingDataCommons/idc-index/issues/100#issuecomment-2264179846. So far I do not know an 'elegant' way to support it


