### PR TITLE
Implementation of instance-level download

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
     rev: "v2.2.6"
     hooks:
       - id: codespell
+        args: ["--quiet-level 3"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.9.0.6"

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -24,7 +24,7 @@ gcp_endpoint_url = "https://storage.googleapis.com"
 asset_endpoint_url = f"https://github.com/ImagingDataCommons/idc-index-data/releases/download/{idc_index_data.__version__}"
 # TODO: remove later
 asset_endpoint_url = (
-    f"https://github.com/ImagingDataCommons/idc-index-data/releases/download/18.2.0"
+    "https://github.com/ImagingDataCommons/idc-index-data/releases/download/18.2.0"
 )
 
 
@@ -129,7 +129,7 @@ class IDCClient:
         patientId,
         studyInstanceUID,
         seriesInstanceUID,
-        sopInstanceUID,
+        sopInstanceUID=None,
     ):
         if collection_id is not None:
             if not isinstance(collection_id, str) and not isinstance(
@@ -1463,7 +1463,10 @@ Destination folder is not empty and sync size is less than total size.
                 index_to_be_filtered = self.sm_instance_index
             else:
                 logger.error(
-                    f"Instance-level access not possible because instance-level index not installed."
+                    "Instance-level access not possible because instance-level index not installed."
+                )
+                raise ValueError(
+                    "Instance-level access not possible because instance-level index not installed."
                 )
         else:
             index_to_be_filtered = self.index

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -202,6 +202,7 @@ class IDCClient:
             "SeriesInstanceUID", df_index, dicom_series_uid
         )
 
+    @staticmethod
     def _filter_by_dicom_instance_uid(df_index, dicom_instance_uid):
         return IDCClient._filter_dataframe_by_id(
             "SOPInstanceUID", df_index, dicom_instance_uid
@@ -1456,10 +1457,14 @@ Destination folder is not empty and sync size is less than total size.
 
         # If SOPInstanceUID(s) are given, we need to join the main index with the instance-level index
         if sopInstanceUID:
-            assert self.indices_overview["sm_instance_index"][
-                "installed"
-            ]  # check if instance-level index is installed
-            index_to_be_filtered = self.sm_instance_index
+            if hasattr(
+                self, "sm_instance_index"
+            ):  # check if instance-level index is installed
+                index_to_be_filtered = self.sm_instance_index
+            else:
+                logger.error(
+                    f"Instance-level access not possible because instance-level index not installed."
+                )
         else:
             index_to_be_filtered = self.index
 
@@ -1795,12 +1800,8 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
 
         index = self.index
         # TODO: find a more elegant way to automate the following
-        try:
+        if hasattr(self, "sm_index"):
             sm_index = self.sm_index
-        except Exception:
-            pass
-        try:
+        if hasattr(self, "sm_instance_index"):
             sm_instance_index = self.sm_instance_index
-        except Exception:
-            pass
         return duckdb.query(sql_query).to_df()

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -175,11 +175,14 @@ class TestIDCClient(unittest.TestCase):
             self.assertEqual(sum([len(files) for r, d, files in os.walk(temp_dir)]), 3)
 
     def test_download_dicom_instance(self):
+        i = IDCClient()
+        i.fetch_index("sm_instance_index")
         with tempfile.TemporaryDirectory() as temp_dir:
             self.client.download_dicom_instance(
                 sopInstanceUID="1.3.6.1.4.1.5962.99.1.528744472.1087975700.1641206284312.14.0",
                 downloadDir=temp_dir,
             )
+
             self.assertEqual(sum([len(files) for r, d, files in os.walk(temp_dir)]), 1)
 
     def test_download_with_template(self):

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -174,6 +174,14 @@ class TestIDCClient(unittest.TestCase):
             )
             self.assertEqual(sum([len(files) for r, d, files in os.walk(temp_dir)]), 3)
 
+    def test_download_dicom_instance(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.client.download_dicom_instance(
+                sopInstanceUID="1.3.6.1.4.1.5962.99.1.528744472.1087975700.1641206284312.14.0",
+                downloadDir=temp_dir,
+            )
+            self.assertEqual(sum([len(files) for r, d, files in os.walk(temp_dir)]), 1)
+
     def test_download_with_template(self):
         dirTemplateValues = [
             None,
@@ -482,10 +490,6 @@ class TestIDCClient(unittest.TestCase):
             # with count equal to 5
             with open(temp_manifest_file) as file:
                 assert len(file.readlines()) == 0
-
-    def test_list_indices(self):
-        i = IDCClient()
-        assert i.indices_overview  # assert that dict was created
 
     def test_fetch_index(self):
         i = IDCClient()


### PR DESCRIPTION
- added support of instance-level download as described in https://github.com/ImagingDataCommons/idc-index/issues/97#issuecomment-2273577579 
- Open problem: we can not estimate / inform the user about download size as we only know the whole series' sizes
- Open problem: especially the IDCClient.download_from_selection() now contains a lot of if-statements and performs a lot of tasks, which makes the code uneasy to read. But this might also be tackled later.  
- Added printing configurations for codespell hook.