### PR TITLE
BUG: use trim to remove any extraneous spaces while parsing s3 url in manifest

### DIFF
--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -665,7 +665,7 @@ class IDCClient:
             SELECT
                 manifest_cp_cmd,
                 REGEXP_EXTRACT(manifest_cp_cmd, '(?:.*?\\/){{3}}([^\\/?#]+)', 1) AS manifest_crdc_series_uuid,
-                REGEXP_REPLACE(regexp_replace(manifest_cp_cmd, 'cp ', ''), '\\s[^\\s]*$', '') AS s3_url,
+                TRIM(REGEXP_REPLACE(regexp_replace(manifest_cp_cmd, 'cp ', ''), '\\s[^\\s]*$', '')) AS s3_url,
             FROM
                 manifest_df )
             SELECT

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -665,7 +665,7 @@ class IDCClient:
             SELECT
                 manifest_cp_cmd,
                 REGEXP_EXTRACT(manifest_cp_cmd, '(?:.*?\\/){{3}}([^\\/?#]+)', 1) AS manifest_crdc_series_uuid,
-                TRIM(REGEXP_REPLACE(regexp_replace(manifest_cp_cmd, 'cp ', ''), '\\s[^\\s]*$', '')) AS s3_url,
+                REGEXP_EXTRACT(manifest_cp_cmd, 's3://\\S+') AS s3_url,
             FROM
                 manifest_df )
             SELECT


### PR DESCRIPTION
Addresses #115 

extraneous spaces throws off the s3 url comparison b/w manifest and index. While I did not investigate much further, this shows that https://github.com/ImagingDataCommons/idc-index/blob/main/idc_index/index.py#L808 is not robust enough, as the validation function was returning 'gcs' endpoint for aws urls.