### PR TITLE
ENH: download clinical data files if clinical_index is requested

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "idc-index-data==19.0.2",
   "packaging",
   "pandas<2.2",
+  "platformdirs",
   "psutil",
   "pyarrow",
   "requests",

--- a/tests/idcindex.py
+++ b/tests/idcindex.py
@@ -556,6 +556,13 @@ class TestIDCClient(unittest.TestCase):
             if i.indices_overview[index]["url"] is not None:
                 assert remote_file_exists(i.indices_overview[index]["url"])
 
+    def test_clinical_index_install(self):
+        i = IDCClient()
+        assert i.indices_overview["clinical_index"]["installed"] is False
+        i.fetch_index("clinical_index")
+        assert i.indices_overview["clinical_index"]["installed"] is True
+        assert len(os.listdir(i.clinical_data_dir)) > 0
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Also address #107 by installing both indices and clinical_data into user directory instead of the python package location.