### PR TITLE
CI/STYLE: Modernize Ruff & pre-commit; clean docstrings; remove blanket noqa; re-enable import sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ ci:
 
 repos:
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.16.0"
+    rev: "1.20.0"
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==24.*]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.5.0"
+    rev: "v6.0.0"
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -32,15 +32,15 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.1.0"
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: "v3.6.2"
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
         args: [--prose-wrap=always]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.2.2"
+    rev: "v0.13.0"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
@@ -57,13 +57,13 @@ repos:
   #        - pytest
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.6"
+    rev: "v2.4.1"
     hooks:
       - id: codespell
         args: ["--quiet-level 3"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.9.0.6"
+    rev: "v0.11.0.1"
     hooks:
       - id: shellcheck
 
@@ -76,7 +76,7 @@ repos:
         exclude: .pre-commit-config.yaml
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.28.0"
+    rev: "0.33.3"
     hooks:
       - id: check-dependabot
       - id: check-github-workflows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,10 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.13.0"
     hooks:
-      - id: ruff
+      # Run the linter
+      - id: ruff-check
         args: ["--fix", "--show-fixes"]
+      # Run the formatter.
       - id: ruff-format
 
   #- repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,11 @@ repos:
         entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
         exclude: .pre-commit-config.yaml
 
+  - repo: https://github.com/henryiii/validate-pyproject-schema-store
+    rev: "2025.09.15"
+    hooks:
+      - id: validate-pyproject
+
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: "0.33.3"
     hooks:

--- a/docs/column_descriptions.md
+++ b/docs/column_descriptions.md
@@ -15,7 +15,6 @@ to select cohorts and subsetting data. `index` is series-based, i.e, it has one
 row per DICOM series.
 
 - non-DICOM attributes assigned/curated by IDC:
-
   - `collection_id`: short string with the identifier of the collection the
     series belongs to
   - `analysis_result_id`: this string is not empty if the specific series is
@@ -94,7 +93,6 @@ The following is the list of the columns included in `sm_instance_index`.
 includes DICOM instances of the slide microscopy modality.
 
 - DICOM attributes extracted from the files:
-
   - `SOPInstanceUID`: unique identifier of the DICOM instance: one DICOM
     instance = one level/label/thumbnail image of the slide
   - `SeriesInstanceUID`: unique identifier of the DICOM series: one DICOM series

--- a/idc_index/__init__.py
+++ b/idc_index/__init__.py
@@ -3,7 +3,6 @@
 idc-index: Package to query and download data from an index of ImagingDataCommons
 """
 
-
 from __future__ import annotations
 
 from ._version import version as __version__

--- a/idc_index/cli.py
+++ b/idc_index/cli.py
@@ -2,6 +2,7 @@
 
 This module provides command-line interface (CLI) commands to interact with the Imaging Data Commons (IDC) data.
 """
+
 from __future__ import annotations
 
 import logging

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -302,17 +302,13 @@ class IDCClient:
 
     @staticmethod
     def get_idc_version():
-        """
-        Returns the version of IDC data used in idc-index
-        """
+        """Returns the version of IDC data used in idc-index."""
         idc_version = Version(idc_index_data.__version__).major
         return f"v{idc_version}"
 
     @staticmethod
     def _check_create_directory(download_dir):
-        """
-        Mimic behavior of s5cmd and create the download directory if it does not exist
-        """
+        """Mimic behavior of s5cmd and create the download directory if it does not exist."""
         download_dir = Path(download_dir)
         download_dir.mkdir(parents=True, exist_ok=True)
 
@@ -328,8 +324,7 @@ class IDCClient:
         return True
 
     def fetch_index(self, index_name) -> None:
-        """
-        Downloads requested index and adds this index joined with the main index as respective class attribute.
+        """Downloads requested index and adds this index joined with the main index as respective class attribute.
 
         Args:
             index (str): Name of the index to be downloaded.
@@ -400,8 +395,7 @@ class IDCClient:
                 )
 
     def get_clinical_table(self, table_name):
-        """
-        Returns the requested clinical table as a pandas DataFrame.
+        """Returns the requested clinical table as a pandas DataFrame.
 
         Args:
             table_name (str): Name of the clinical table to be loaded.
@@ -423,15 +417,12 @@ class IDCClient:
         return pd.read_parquet(table_path)
 
     def get_collections(self):
-        """
-        Returns the collections present in IDC
-        """
+        """Returns the collections present in IDC."""
         unique_collections = self.index["collection_id"].unique()
         return unique_collections.tolist()
 
     def get_series_size(self, seriesInstanceUID):
-        """
-        Gets cumulative size (MB) of the DICOM instances in a given SeriesInstanceUID.
+        """Gets cumulative size (MB) of the DICOM instances in a given SeriesInstanceUID.
 
         Args:
             seriesInstanceUID (str): The DICOM SeriesInstanceUID.
@@ -449,8 +440,7 @@ class IDCClient:
         return resp
 
     def get_patients(self, collection_id, outputFormat="dict"):
-        """
-        Gets the patients in a collection.
+        """Gets the patients in a collection.
 
         Args:
             collection_id (str or list[str]): The collection id or list of collection ids. This should be in lower case separated by underscores.
@@ -500,8 +490,7 @@ class IDCClient:
         return response
 
     def get_dicom_studies(self, patientId, outputFormat="dict"):
-        """
-        Returns Studies for a given patient or list of patients.
+        """Returns Studies for a given patient or list of patients.
 
         Args:
             patientId (str or list of str): The patient Id or a list of patient Ids.
@@ -552,8 +541,7 @@ class IDCClient:
         return response
 
     def get_dicom_series(self, studyInstanceUID, outputFormat="dict"):
-        """
-        Returns Series for a given study or list of studies.
+        """Returns Series for a given study or list of studies.
 
         Args:
             studyInstanceUID (str or list of str): The DICOM StudyInstanceUID or a list of StudyInstanceUIDs.
@@ -625,8 +613,7 @@ class IDCClient:
         return response
 
     def get_series_file_URLs(self, seriesInstanceUID, source_bucket_location="aws"):
-        """
-        Get the URLs of the files corresponding to the DICOM instances in a given SeriesInstanceUID.
+        """Get the URLs of the files corresponding to the DICOM instances in a given SeriesInstanceUID.
 
         Args:
             seriesInstanceUID: string containing the value of DICOM SeriesInstanceUID to filter by
@@ -686,8 +673,7 @@ class IDCClient:
         return file_names
 
     def get_instance_file_URL(self, sopInstanceUID, source_bucket_location="aws"):
-        """
-        Get the bucket URL of the file corresponding to a given SOPInstanceUID.
+        """Get the bucket URL of the file corresponding to a given SOPInstanceUID.
 
         This function will only return the URL for the Slide Microscopy (SM) instances,
         which are maintained in the `sm_instance_index` table.
@@ -739,8 +725,7 @@ class IDCClient:
     def get_viewer_URL(
         self, seriesInstanceUID=None, studyInstanceUID=None, viewer_selector=None
     ):
-        """
-        Get the URL of the IDC viewer for the given series or study in IDC based on
+        """Get the URL of the IDC viewer for the given series or study in IDC based on
         the provided SeriesInstanceUID or StudyInstanceUID. If StudyInstanceUID is not provided,
         it will be automatically deduced. If viewer_selector is not provided, default viewers
         will be used (OHIF v3 for radiology modalities, and Slim for SM).
@@ -851,8 +836,7 @@ class IDCClient:
         use_s5cmd_sync,
         dirTemplate,
     ) -> tuple[float, str, Path]:
-        """
-        Validates the manifest file by checking the URLs in the manifest
+        """Validates the manifest file by checking the URLs in the manifest.
 
         Args:
             manifestFile (str): The path to the manifest file.
@@ -1303,8 +1287,7 @@ class IDCClient:
     def _parse_s5cmd_sync_output_and_generate_synced_manifest(
         self, stdout, s5cmd_sync_helper_df
     ) -> Path:
-        """
-        Parse the output of s5cmd sync --dry-run to extract distinct folders and generate a synced manifest.
+        """Parse the output of s5cmd sync --dry-run to extract distinct folders and generate a synced manifest.
 
         Args:
             output (str): The output of s5cmd sync --dry-run command.
@@ -1384,8 +1367,7 @@ class IDCClient:
         s5cmd_sync_helper_df,
         progress_callback=None,
     ):
-        """
-        Executes the s5cmd command to sync files from a given endpoint to a local directory.
+        """Executes the s5cmd command to sync files from a given endpoint to a local directory.
 
         This function first performs a dry run of the s5cmd command to check which files need to be downloaded.
         If there are files to be downloaded, it generates a new manifest file with the files to be synced and
@@ -1596,8 +1578,7 @@ Destination folder is not empty and sync size is less than total size.
         dirTemplate=DOWNLOAD_HIERARCHY_DEFAULT,
         progress_callback: Callable[[float, float, str, str], None] = None,
     ) -> None:
-        """
-        Download the manifest file. In a series of steps, the manifest file
+        """Download the manifest file. In a series of steps, the manifest file
         is first validated to ensure every line contains a valid urls. It then
         gets the total size to be downloaded and runs download process on one
         process and download progress on another process.
@@ -2009,8 +1990,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
         dirTemplate=DOWNLOAD_HIERARCHY_DEFAULT,
         source_bucket_location="aws",
     ) -> None:
-        """
-        Download the files corresponding to the seriesInstanceUID to the specified directory.
+        """Download the files corresponding to the seriesInstanceUID to the specified directory.
 
         Args:
             sopInstanceUID: string or list of strings containing the values of DICOM SOPInstanceUID to filter by
@@ -2049,8 +2029,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
         dirTemplate=DOWNLOAD_HIERARCHY_DEFAULT,
         source_bucket_location="aws",
     ) -> None:
-        """
-        Download the files corresponding to the seriesInstanceUID to the specified directory.
+        """Download the files corresponding to the seriesInstanceUID to the specified directory.
 
         Args:
             seriesInstanceUID: string or list of strings containing the values of DICOM SeriesInstanceUID to filter by
@@ -2089,8 +2068,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
         dirTemplate=DOWNLOAD_HIERARCHY_DEFAULT,
         source_bucket_location="aws",
     ) -> None:
-        """
-        Download the files corresponding to the studyInstanceUID to the specified directory.
+        """Download the files corresponding to the studyInstanceUID to the specified directory.
 
         Args:
             studyInstanceUID: string or list of strings containing the values of DICOM studyInstanceUID to filter by
@@ -2129,8 +2107,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
         dirTemplate=DOWNLOAD_HIERARCHY_DEFAULT,
         source_bucket_location="aws",
     ) -> None:
-        """
-        Download the files corresponding to the studyInstanceUID to the specified directory.
+        """Download the files corresponding to the studyInstanceUID to the specified directory.
 
         Args:
             patientId: string or list of strings containing the values of DICOM patientId to filter by
@@ -2170,8 +2147,7 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
         dirTemplate=DOWNLOAD_HIERARCHY_DEFAULT,
         source_bucket_location="aws",
     ) -> None:
-        """
-        Download the files corresponding to the studyInstanceUID to the specified directory.
+        """Download the files corresponding to the studyInstanceUID to the specified directory.
 
         Args:
             collection_id: string or list of strings containing the values of DICOM patientId to filter by

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -334,7 +334,6 @@ class IDCClient:
         Args:
             index (str): Name of the index to be downloaded.
         """
-
         if index_name not in self.indices_overview:
             logger.error(f"Index {index_name} is not available and can not be fetched.")
         elif self.indices_overview[index_name]["installed"]:
@@ -466,7 +465,6 @@ class IDCClient:
         Raises:
             ValueError: If `outputFormat` is not one of 'dict', 'df', 'list'.
         """
-
         if not isinstance(collection_id, str) and not isinstance(collection_id, list):
             raise TypeError("collection_id must be a string or list of strings")
 
@@ -518,7 +516,6 @@ class IDCClient:
             ValueError: If `outputFormat` is not one of 'dict', 'df', 'list'.
             ValueError: If any of the `patientId` does not exist.
         """
-
         if not isinstance(patientId, str) and not isinstance(patientId, list):
             raise TypeError("patientId must be a string or list of strings")
 
@@ -571,7 +568,6 @@ class IDCClient:
             ValueError: If `outputFormat` is not one of 'dict', 'df', 'list'.
             ValueError: If any of the `studyInstanceUID` does not exist.
         """
-
         if not isinstance(studyInstanceUID, str) and not isinstance(
             studyInstanceUID, list
         ):
@@ -704,7 +700,6 @@ class IDCClient:
             string containing the bucket URL of the file corresponding to the SOPInstanceUID,
             or None if the SOPInstanceUID is not recognized
         """
-
         # sm_instance_index is required to complete this operation - install it!
         self.fetch_index("sm_instance_index")
 
@@ -766,7 +761,6 @@ class IDCClient:
         Returns:
             string containing the IDC viewer URL for the requested selection
         """
-
         if seriesInstanceUID is None and studyInstanceUID is None:
             raise ValueError(
                 "Either SeriesInstanceUID or StudyInstanceUID, or both, must be provided."
@@ -1621,7 +1615,6 @@ Destination folder is not empty and sync size is less than total size.
         Raises:
             ValueError: If the download directory does not exist.
         """
-
         downloadDir = self._check_create_directory(downloadDir)
 
         # validate the manifest
@@ -1671,7 +1664,6 @@ Destination folder is not empty and sync size is less than total size.
         Returns:
             List of citations in the requested format.
         """
-
         manifest_df = pd.read_csv(
             manifestFile,
             comment="#",
@@ -1715,7 +1707,6 @@ Destination folder is not empty and sync size is less than total size.
         Returns:
             List of citations in the requested format.
         """
-
         result_df = self._safe_filter_by_selection(
             self.index,
             collection_id=collection_id,
@@ -1800,7 +1791,6 @@ Destination folder is not empty and sync size is less than total size.
             dirTemplate (str): Download directory hierarchy template. This variable defines the folder hierarchy for the organizing the downloaded files in downloadDirectory. Defaults to index.DOWNLOAD_HIERARCHY_DEFAULT set to %collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID. The template string can be built using a combination of selected metadata attributes (PatientID, collection_id, Modality, StudyInstanceUID, SeriesInstanceUID) that must be prefixed by '%'. The following special characters can be used as separators: '-' (hyphen), '/' (slash for subdirectories), '_' (underscore). When set to None all files will be downloaded to the download directory with no subdirectories.
             source_bucket_location: string selecting the provider of the bucket from which the files will be downloaded, allowing to select between Google ('gcs') and AWS ('aws') storage. Defaults to 'aws'.
         """
-
         if source_bucket_location not in ["aws", "gcs"]:
             raise ValueError("source_bucket_location must be either 'aws' or 'gcs'")
 
@@ -2222,7 +2212,6 @@ Temporary download manifest is generated and is passed to self._s5cmd_run
         Raises:
             duckdb.Error: any exception that duckdb.query() raises
         """
-
         logger.debug("Executing SQL query: " + sql_query)
         # TODO: find a more elegant way to automate the following:  https://www.perplexity.ai/search/write-python-code-that-iterate-XY9ppywbQFSRnOpgbwx_uQ
         index = self.index

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -1243,13 +1243,13 @@ class IDCClient:
                     downloaded_bytes += IDCClient._get_dir_sum_file_size(directory)
                 downloaded_bytes -= initial_size_bytes
 
-                if not pbar is None:
+                if pbar is not None:
                     pbar.n = min(
                         downloaded_bytes, total_size_to_be_downloaded_bytes
                     )  # Prevent the progress bar from exceeding 100%
                     pbar.refresh()
 
-                if not progress_callback is None:
+                if progress_callback is not None:
                     progress_callback(
                         min(downloaded_bytes, total_size_to_be_downloaded_bytes),
                         total_size_to_be_downloaded_bytes,
@@ -1262,7 +1262,7 @@ class IDCClient:
             # Wait for the process to finish
             _, stderr = process.communicate()
 
-            if not pbar is None:
+            if pbar is not None:
                 pbar.close()
 
         else:
@@ -1909,7 +1909,7 @@ Destination folder is not empty and sync size is less than total size.
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as manifest_file:
             # Determine column containing the URL for instance / series-level access
             if sopInstanceUID:
-                if not "instance_aws_url" in result_df:
+                if "instance_aws_url" not in result_df:
                     result_df["instance_aws_url"] = (
                         result_df["series_aws_url"].replace("/*", "/")
                         + result_df["crdc_instance_uuid"]

--- a/idc_index/index.py
+++ b/idc_index/index.py
@@ -908,7 +908,6 @@ class IDCClient:
         # Next, construct aws_series_url in the index and
         # try to verify if every series in the manifest is present in the index
 
-        # ruff: noqa
         sql = f"""
             PRAGMA disable_progress_bar;
             WITH
@@ -952,7 +951,6 @@ class IDCClient:
             ON
                 index_temp.index_crdc_series_uuid = manifest_temp.manifest_crdc_series_uuid
         """
-        # ruff: noqa: end
         merged_df = duckdb.query(sql).df()
 
         endpoint_to_use = None
@@ -1308,7 +1306,6 @@ class IDCClient:
         result_df = s5cmd_sync_helper_df
 
         # TODO: need to remove the assumption that manifest commands will have 'cp'
-        # ruff: noqa
         sql = """
             PRAGMA disable_progress_bar;
             WITH
@@ -1337,7 +1334,6 @@ class IDCClient:
             ON
                 index_temp.index_crdc_series_uuid = sync_temp.sync_crdc_instance_uuid
         """
-        # ruff: noqa: end
         synced_df = duckdb.query(sql).df()
         sync_size = synced_df["series_size_MB"].sum()
         sync_size_rounded = round(sync_size, 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ test = [
 dev = [
   "pytest >=6",
   "pytest-cov >=3",
-  "ruff ==0.12.11"
 ]
 docs = [
   "sphinx>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,6 @@ ignore = [
   "G004",     # Logging statement uses f-string
   "PD011",    # Use .to_numpy() instead of .values
   "PD015",    # Use `.merge` method instead of `pd.merge` function.
-  "PD901",    # Avoid using the generic variable name df for DataFrames
   "PLR5501",  # Checks for else blocks that consist of a single if statement.
   "PT009",    # Use a regular assert instead of unittest-style {assertion}
   "PTH100",   # os.path.abspath() should be replaced by Path.resolve()
@@ -187,9 +186,11 @@ ignore = [
   "PTH119",   # os.path.basename() should be replaced by Path.name
   "PTH120",   # os.path.dirname() should be replaced by Path.parent
   "PTH123",   # open() should be replaced by Path.open()
+  "PTH208",   # Checks for uses of os.listdir.
   "RET504",   # Unnecessary assignment to {name} before return statement
   "RET506",   # Unnecessary {branch} after raise statement
   "RUF013",   # PEP 484 prohibits implicit `Optional`
+  "RUF059",   # Unpacked variable `stderr` is never used
   "SIM102",   # Use a single if statement instead of nested if statements
   "SIM105",   # Use `contextlib.suppress(FileNotFoundError)` instead of `try`-`except`-`pass`
   "SIM108",   # Use ternary operator {contents} instead of if-else-block

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ extend-exclude = ["./CONTRIBUTING.md"]
 [tool.ruff.lint]
 extend-select = [
   "B",        # flake8-bugbear
+  "I",        # isort
   "ARG",      # flake8-unused-arguments
   "C4",       # flake8-comprehensions
   "D",        # pydocstyle
@@ -199,7 +200,7 @@ ignore = [
   "SIM300",   # Yoda condition detected
   "T201",     # print found
 ]
-
+isort.required-imports = ["from __future__ import annotations"]
 # Uncomment if using a _compat.typing backport
 # typing-modules = ["idc_index._compat.typing"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,14 +160,25 @@ ignore = [
   "ISC001",   # Conflicts with formatter
   # Exceptions below are specific to idc-index
   "B007",     # Loop control variable {name} not used within loop body
+  "B009",     # Do not call `getattr` with a constant attribute value.
+  "B010",     # Do not call `setattr` with a constant attribute value.
   "B904",     # Checks for raise statements in exception handlers that lack a from clause.
+  "D100",     # Missing docstring in public module
+  "D101",     # Missing docstring in public class
+  "D102",     # Missing docstring in public method
+  "D107",     # Missing docstring in `__init__`"
+  "D417",     # Missing argument description in the docstring
+  "D202",     # Checks for docstrings on functions that are separated by one or more blank lines from the function body.
+  "D205",     # 1 blank line required between summary line and description
   "E722",     # Do not use bare except
   "EM101",    # Exception must not use a string literal, assign to variable first
   "F841",     # Local variable {name} is assigned to but never used
   "G003",     # Logging statement uses +
   "G004",     # Logging statement uses f-string
   "PD011",    # Use .to_numpy() instead of .values
+  "PD015",    # Use `.merge` method instead of `pd.merge` function.
   "PD901",    # Avoid using the generic variable name df for DataFrames
+  "PLR5501",  # Checks for else blocks that consist of a single if statement.
   "PT009",    # Use a regular assert instead of unittest-style {assertion}
   "PTH100",   # os.path.abspath() should be replaced by Path.resolve()
   "PTH103",   # os.makedirs() should be replaced by Path.mkdir(parents=True)
@@ -179,9 +190,13 @@ ignore = [
   "PTH123",   # open() should be replaced by Path.open()
   "RET504",   # Unnecessary assignment to {name} before return statement
   "RET506",   # Unnecessary {branch} after raise statement
+  "RUF013",   # PEP 484 prohibits implicit `Optional`
   "SIM102",   # Use a single if statement instead of nested if statements
+  "SIM105",   # Use `contextlib.suppress(FileNotFoundError)` instead of `try`-`except`-`pass`
   "SIM108",   # Use ternary operator {contents} instead of if-else-block
+  "SIM115",   # Use a context manager for opening files
   "SIM117",   # Use a single with statement with multiple contexts instead of nested with statements
+  "SIM300",   # Yoda condition detected
   "T201",     # print found
 ]
 


### PR DESCRIPTION
This PR modernizes our linting/formatting toolchain and applies the minimal code/style edits needed to pass it. It also reintroduces safe checks we previously disabled (imports sorting) and adds schema validation for `pyproject.toml`.

**Ruff / config**

* CI: Remove blanket `# ruff: noqa` segments (fixes `PGH004`) and add explicit Ruff rule exceptions in `pyproject.toml`.
* CI: Drop unused pinned Ruff version from dev deps in `pyproject.toml`.
* CI: Reintroduce `"I"` (isort) checks.
 
**Code style & docs**

* STYLE: Normalize empty lines anticipating proper `noqa` usage.
* DOC: Rewrite docstrings to satisfy `pydocstyle` (e.g., D200, D415).
* STYLE: Prefer `is not` / `not in` forms (Ruff E714).

**pre-commit & validation**

* CI: Update pre-commit hooks to current releases; switch to maintained Prettier mirror; adjust Ruff exceptions:
  * Add `PTH208` (Ruff 0.10+), remove obsolete `PD901` (Ruff 0.13).
  * Minor markdown update to satisfy newer Prettier.
* CI: Adopt preferred `ruff-check` hook name.
* CI: Re-introduce `validate-pyproject` via `validate-pyproject-schema-store`.
