### PR TITLE
enh: improve handling of indices

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,6 +27,38 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Read idc-index-data version from pyproject.toml
+        run: |
+          python - <<'PY' > /tmp/idc_ver.env
+          import tomllib, re
+          with open('pyproject.toml','rb') as f:
+              data = tomllib.load(f)
+          ver = None
+          for d in data['project']['dependencies']:
+              m = re.match(r'idc-index-data==(.+)', d)
+              if m:
+                  ver = m.group(1)
+                  break
+          assert ver, 'idc-index-data version not found in pyproject.toml'
+          print(f'IDC_INDEX_DATA_VERSION={ver}')
+          PY
+          cat /tmp/idc_ver.env >> $GITHUB_ENV
+
+      - name: Preinstall idc-index-data for cache generation
+        env:
+          IDC_INDEX_DATA_VERSION: ${{ env.IDC_INDEX_DATA_VERSION }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "idc-index-data==${IDC_INDEX_DATA_VERSION}"
+
+      - name: Generate bundled indices cache
+        run: |
+          python scripts/generate_indices_cache.py
+
       - uses: hynek/build-and-inspect-python-package@v2
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,34 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
+      - name: Read idc-index-data version from pyproject.toml
+        run: |
+          python - <<'PY' > /tmp/idc_ver.env
+          import tomllib, re
+          with open('pyproject.toml','rb') as f:
+              data = tomllib.load(f)
+          ver = None
+          for d in data['project']['dependencies']:
+              m = re.match(r'idc-index-data==(.+)', d)
+              if m:
+                  ver = m.group(1)
+                  break
+          assert ver, 'idc-index-data version not found in pyproject.toml'
+          print(f'IDC_INDEX_DATA_VERSION={ver}')
+          PY
+          cat /tmp/idc_ver.env >> $GITHUB_ENV
+
+      - name: Preinstall idc-index-data for cache generation
+        env:
+          IDC_INDEX_DATA_VERSION: ${{ env.IDC_INDEX_DATA_VERSION }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "idc-index-data==${IDC_INDEX_DATA_VERSION}"
+
+      - name: Generate bundled indices cache
+        run: |
+          python scripts/generate_indices_cache.py
+
       - name: Install package
         run: python -m pip install .[test]
 

--- a/idc_index/indices_util.py
+++ b/idc_index/indices_util.py
@@ -1,0 +1,114 @@
+"""Shared utilities for discovering and caching index metadata."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_indices_from_github(
+    version: str, asset_endpoint_url: str, pre_installed_indices: dict[str, Any]
+) -> dict[str, Any]:
+    """Fetch available indices and their schemas from GitHub releases."""
+    indices = pre_installed_indices.copy()
+
+    # Fetch schemas for pre-installed indices
+    for index_name in list(pre_installed_indices.keys()):
+        json_url = f"{asset_endpoint_url}/{index_name}.json"
+        try:
+            schema_response = requests.get(json_url, timeout=30)
+            if schema_response.status_code == 200:
+                schema_data = schema_response.json()
+                description = schema_data.get(
+                    "table_description", indices[index_name]["description"]
+                )
+                indices[index_name]["description"] = description
+                indices[index_name]["table_description"] = schema_data.get(
+                    "table_description"
+                )
+                indices[index_name]["columns"] = schema_data.get("columns", [])
+                logger.debug(f"Fetched schema for pre-installed index {index_name}")
+        except Exception as e:
+            logger.debug(f"Error fetching schema for {index_name}: {e}")
+
+    # Discover additional indices from GitHub releases
+    try:
+        api_url = f"https://api.github.com/repos/ImagingDataCommons/idc-index-data/releases/tags/{version}"
+        logger.debug(f"Querying GitHub API: {api_url}")
+        response = requests.get(api_url, timeout=30)
+
+        if response.status_code == 200:
+            release_data = response.json()
+            assets = release_data.get("assets", [])
+            parquet_assets = [
+                asset["name"] for asset in assets if asset["name"].endswith(".parquet")
+            ]
+
+            for parquet_name in parquet_assets:
+                index_name = parquet_name.replace(".parquet", "")
+                if index_name in pre_installed_indices:
+                    continue
+
+                json_url = f"{asset_endpoint_url}/{index_name}.json"
+                description = f"Index table: {index_name}"
+                schema_data = None
+
+                try:
+                    schema_response = requests.get(json_url, timeout=30)
+                    if schema_response.status_code == 200:
+                        schema_data = schema_response.json()
+                        description = schema_data.get("table_description", description)
+                except Exception as e:
+                    logger.warning(f"Error fetching schema for {index_name}: {e}")
+
+                indices[index_name] = {
+                    "description": description,
+                    "installed": False,
+                    "url": f"{asset_endpoint_url}/{parquet_name}",
+                    "file_path": None,
+                }
+
+                if schema_data:
+                    indices[index_name]["table_description"] = schema_data.get(
+                        "table_description"
+                    )
+                    indices[index_name]["columns"] = schema_data.get("columns", [])
+
+    except Exception as e:
+        logger.warning(f"Error during index discovery: {e}")
+
+    return indices
+
+
+def save_indices_cache(
+    cache_file_path: str, version: str, indices: dict[str, Any]
+) -> None:
+    """Save indices metadata to cache file."""
+    try:
+        os.makedirs(os.path.dirname(cache_file_path), exist_ok=True)
+        cache_data = {"version": version, "indices": indices}
+        with open(cache_file_path, "w") as f:
+            json.dump(cache_data, f, indent=2)
+        logger.debug(f"Cached indices list to {cache_file_path}")
+    except Exception as e:
+        logger.warning(f"Failed to cache indices list: {e}")
+
+
+def load_indices_cache(cache_file_path: str) -> dict[str, Any] | None:
+    """Load indices metadata from cache file."""
+    if not os.path.exists(cache_file_path):
+        return None
+    try:
+        with open(cache_file_path) as f:
+            cache_data = json.load(f)
+            if "version" in cache_data and "indices" in cache_data:
+                return cache_data
+    except (json.JSONDecodeError, KeyError) as e:
+        logger.warning(f"Failed to read indices cache: {e}")
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,11 @@ build.hooks.vcs.version-file = "idc_index/_version.py"
 features = ["test"]
 scripts.test = "pytest {args}"
 
+[tool.hatch.build.targets.wheel]
+packages = ["idc_index"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"idc_index/indices_cache.json" = "idc_index/indices_cache.json"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -239,4 +244,5 @@ messages_control.disable = [
   "undefined-loop-variable",
   "unspecified-encoding",
   "unused-variable",
+  "broad-exception-caught",
 ]

--- a/scripts/generate_indices_cache.py
+++ b/scripts/generate_indices_cache.py
@@ -1,0 +1,138 @@
+"""Generate indices cache at build time."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import idc_index_data
+import requests
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def fetch_indices_from_github(
+    version: str, asset_endpoint_url: str, pre_installed_indices: dict
+) -> dict:
+    """Fetch available indices and their schemas from GitHub releases."""
+    indices = pre_installed_indices.copy()
+
+    # Fetch schemas for pre-installed indices
+    for index_name in list(pre_installed_indices.keys()):
+        json_url = f"{asset_endpoint_url}/{index_name}.json"
+        try:
+            schema_response = requests.get(json_url, timeout=30)
+            if schema_response.status_code == 200:
+                schema_data = schema_response.json()
+                description = schema_data.get(
+                    "table_description", indices[index_name]["description"]
+                )
+                indices[index_name]["description"] = description
+                indices[index_name]["table_description"] = schema_data.get(
+                    "table_description"
+                )
+                indices[index_name]["columns"] = schema_data.get("columns", [])
+                logger.debug(f"Fetched schema for pre-installed index {index_name}")
+        except Exception as e:
+            logger.debug(f"Error fetching schema for {index_name}: {e}")
+
+    # Discover additional indices from GitHub releases
+    try:
+        api_url = f"https://api.github.com/repos/ImagingDataCommons/idc-index-data/releases/tags/{version}"
+        logger.debug(f"Querying GitHub API: {api_url}")
+        response = requests.get(api_url, timeout=30)
+
+        if response.status_code == 200:
+            release_data = response.json()
+            assets = release_data.get("assets", [])
+            parquet_assets = [
+                asset["name"] for asset in assets if asset["name"].endswith(".parquet")
+            ]
+
+            for parquet_name in parquet_assets:
+                index_name = parquet_name.replace(".parquet", "")
+                if index_name in pre_installed_indices:
+                    continue
+
+                json_url = f"{asset_endpoint_url}/{index_name}.json"
+                description = f"Index table: {index_name}"
+                schema_data = None
+
+                try:
+                    schema_response = requests.get(json_url, timeout=30)
+                    if schema_response.status_code == 200:
+                        schema_data = schema_response.json()
+                        description = schema_data.get("table_description", description)
+                except Exception as e:
+                    logger.warning(f"Error fetching schema for {index_name}: {e}")
+
+                indices[index_name] = {
+                    "description": description,
+                    "installed": False,
+                    "url": f"{asset_endpoint_url}/{parquet_name}",
+                    "file_path": None,
+                }
+
+                if schema_data:
+                    indices[index_name]["table_description"] = schema_data.get(
+                        "table_description"
+                    )
+                    indices[index_name]["columns"] = schema_data.get("columns", [])
+
+    except Exception as e:
+        logger.warning(f"Error during index discovery: {e}")
+
+    return indices
+
+
+def save_indices_cache(cache_file_path: str, version: str, indices: dict) -> None:
+    """Save indices metadata to cache file."""
+    try:
+        os.makedirs(os.path.dirname(cache_file_path), exist_ok=True)
+        cache_data = {"version": version, "indices": indices}
+        with open(cache_file_path, "w") as f:
+            json.dump(cache_data, f, indent=2)
+        logger.debug(f"Cached indices list to {cache_file_path}")
+    except Exception as e:
+        logger.warning(f"Failed to cache indices list: {e}")
+
+
+def main():
+    """Generate indices cache for the current idc-index-data version."""
+    version = idc_index_data.__version__
+    asset_endpoint_url = f"https://github.com/ImagingDataCommons/idc-index-data/releases/download/{version}"
+
+    # Define pre-installed indices
+    pre_installed_indices = {
+        "idc_index": {
+            "description": "Main index containing one row per DICOM series.",
+            "installed": True,
+            "url": None,
+            "file_path": str(idc_index_data.IDC_INDEX_PARQUET_FILEPATH),
+        },
+        "prior_versions_index": {
+            "description": "index containing one row per DICOM series from all previous IDC versions that are not in current version.",
+            "installed": True,
+            "url": None,
+            "file_path": str(idc_index_data.PRIOR_VERSIONS_INDEX_PARQUET_FILEPATH),
+        },
+    }
+
+    logger.info(f"Generating indices cache for version {version}")
+    indices = fetch_indices_from_github(
+        version, asset_endpoint_url, pre_installed_indices
+    )
+
+    # Save to package data directory
+    cache_file = Path(__file__).parent.parent / "idc_index" / "indices_cache.json"
+    save_indices_cache(str(cache_file), version, indices)
+
+    logger.info(f"Successfully generated cache with {len(indices)} indices")
+    logger.info(f"Cache saved to: {cache_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* discover indices available from what idc-index-data bundles
* initialize index cache at the time idc-index package is created
* fetch schema of the extra indices along with the index itself

Co-authored with Copilot