### PR TITLE
doc: fix regression due to sphinx dependencies changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
   "pyarrow",
   "requests",
   "s5cmd>=0.3.2",
-  "sphinx-click",
   "tqdm"
 ]
 
@@ -54,10 +53,11 @@ dev = [
   "pytest-cov >=3",
 ]
 docs = [
-  "sphinx>=7.0",
-  "myst_parser>=0.13",
+  "sphinx>=7.0,<8",
+  "myst_parser>=0.13,<5.0",
   "sphinx_copybutton",
   "sphinx_autodoc_typehints",
+  "sphinx-click",
   "furo>=2023.08.17",
   "sphinxcontrib-mermaid",
 ]


### PR DESCRIPTION
Co-authored by Claude

---

# Fix: sphinx-click Mock Import Error in Documentation Build

## Error

`TypeError: 'module' object is not callable`


Location: `sphinx_click/ext.py:459` when calling `mock(self.env.config.sphinx_click_mock_imports)`

## Root Cause

1. **MyST-Parser 5.0.0** was released on **January 15, 2026** requiring **Sphinx >=8**
2. The workflow last succeeded on January 12 (before this release)
3. `pyproject.toml` specified `myst_parser>=0.13` which resolved to 5.0.0
4. MyST-Parser 5.0.0 pulled in Sphinx 8.x
5. In Sphinx 8.x, `sphinx.ext.autodoc.mock` was accidentally removed
6. The fix was released in **Sphinx 9.0.2** (Dec 3, 2025)
7. sphinx-click's import `from sphinx.ext.autodoc import mock` failed on Sphinx 8.x

## Changes Made

**File:** `pyproject.toml`

| Change | Before | After |
|--------|--------|-------|
| Remove sphinx-click from main deps | `"sphinx-click",` in dependencies | Removed |
| Pin Sphinx version | `"sphinx>=7.0"` | `"sphinx>=7.0,<8"` |
| Pin MyST-Parser version | `"myst_parser>=0.13"` | `"myst_parser>=0.13,<5.0"` |
| Add sphinx-click to docs deps | Not present | `"sphinx-click"` added |
