### PR TITLE
BUG: pin sphinxcontrib-mermaid<2 to fix broken Mermaid diagram rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
   "sphinx_autodoc_typehints",
   "sphinx-click",
   "furo>=2023.08.17",
-  "sphinxcontrib-mermaid",
+  "sphinxcontrib-mermaid<2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

The Mermaid ER diagram on the [indices_reference](https://idc-index.readthedocs.io/en/latest/indices_reference.html) docs page is broken — it shows raw Mermaid code as plain text instead of a rendered diagram.

## Root cause analysis

`sphinxcontrib-mermaid` was unpinned in `pyproject.toml` and auto-upgraded from **1.2.3** to **2.0.x** on ReadTheDocs (2.0.0 released Jan 13, 2026; 2.0.1 released Mar 5, 2026).

Version 2.0.0 introduced several breaking changes that affect this project:

1. **`mermaid_init_js` config was removed** — replaced by `mermaid_init_config` (a dict instead of a JS string). Our custom `mermaid_init_js` in `docs/conf.py` is silently ignored in v2.0.0, meaning the custom theme configuration and `startOnLoad: true` setting have no effect.

2. **The JS rendering pipeline was completely rewritten** — v2.0.0 always sets `startOnLoad: false` and relies on a new `mermaid.run()` flow with theme change detection, fullscreen support, and d3 zoom integration all handled in a single Jinja2-templated module script. This new pipeline fails to render the diagrams.

3. **`mermaid_fullscreen` now defaults to `True`** — this changes the code path for zoom integration. When both `mermaid_d3_zoom = True` (our config) and `mermaid_fullscreen = True` (new default), the JS follows a combined fullscreen+zoom path that didn't exist in v1.2.3.

In v1.2.3, even though our custom `mermaid_init_js` was technically failing silently (the extension didn't prepend the `import mermaid` statement for non-default init values), a separate internal `_MERMAID_RUN` script independently imported mermaid and called `mermaid.run()`, so diagrams rendered correctly. In v2.0.0, that separate script is gone and the unified JS template doesn't render the diagrams.

## Fix

Pin `sphinxcontrib-mermaid<2` in `pyproject.toml` to restore the working v1.2.3 behavior.

## Future considerations

To upgrade to v2.0.0+ in the future, the following `docs/conf.py` changes would be needed:
- Replace `mermaid_init_js` with `mermaid_init_config` (dict format, e.g. `{"startOnLoad": False, "themeVariables": {...}}`)
- Note that v2.0.0 overrides the `theme` key with automatic dark/light detection, so `theme: 'base'` from our config would not apply
- Test that the new fullscreen+zoom JS pipeline renders the ER diagram correctly
- There are open upstream issues related to this: [#178](https://github.com/mgaitan/sphinxcontrib-mermaid/issues/178), [#227](https://github.com/mgaitan/sphinxcontrib-mermaid/issues/227)

🤖 Generated with [Claude Code](https://claude.com/claude-code)