### PR TITLE
CI: run pre-commit before change detection in update-indices-docs workflow

### DIFF
--- a/.github/workflows/update-indices-docs.yml
+++ b/.github/workflows/update-indices-docs.yml
@@ -43,6 +43,12 @@ jobs:
           cd docs
           sphinx-build -W -b html . _build/html
 
+      - name: Run pre-commit on generated docs
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --files docs/indices_reference.md
+        continue-on-error: true
+
       - name: Check for changes
         id: git-check
         run: |


### PR DESCRIPTION
Prevents false PRs (such as #252) when the generate script produces formatting-only differences that pre-commit CI would later revert, resulting in PRs with empty diffs.